### PR TITLE
Fix malformed markdown at source (#1963)

### DIFF
--- a/tutorials/sdk-android-app-link/sdk-android-app-link.md
+++ b/tutorials/sdk-android-app-link/sdk-android-app-link.md
@@ -101,30 +101,30 @@ As you primarily use the mobile application, you want to click on the link to op
 
 5. Locate the inserted code block.
 
-    ```kotlin
-    // ATTENTION: This was auto-generated to handle app links.
-    val appLinkIntent: Intent = intent
-    val appLinkAction: String? = appLinkIntent.action
-    val appLinkData: Uri? = appLinkIntent.data
-    ```
+   ```kotlin
+   // ATTENTION: This was auto-generated to handle app links.
+   val appLinkIntent: Intent = intent
+   val appLinkAction: String? = appLinkIntent.action
+   val appLinkData: Uri? = appLinkIntent.data
+   ```
 
 6. Add the following code after the inserted code block.
 
-    ```kotlin
-    appLinkData?.let { uri ->
-            val pathSegments: List<String> = uri.pathSegments
+   ```kotlin
+   appLinkData?.let { uri ->
+           val pathSegments: List<String> = uri.pathSegments
 
-            if (pathSegments.isNotEmpty()) {
-                val lastPathSegment: String = pathSegments.last()
+           if (pathSegments.isNotEmpty()) {
+               val lastPathSegment: String = pathSegments.last()
 
-                if (lastPathSegment == "product") {
-                    Toast.makeText(this, "Product App Link", Toast.LENGTH_SHORT).show()
-                } else if (lastPathSegment == "vendor") {
-                    Toast.makeText(this, "Vendor App Link", Toast.LENGTH_SHORT).show()
-                }
-            }
-    }
-    ```
+               if (lastPathSegment == "product") {
+                   Toast.makeText(this, "Product App Link", Toast.LENGTH_SHORT).show()
+               } else if (lastPathSegment == "vendor") {
+                   Toast.makeText(this, "Vendor App Link", Toast.LENGTH_SHORT).show()
+               }
+           }
+   }
+   ```
 
     > Ensure that the necessary libraries are imported.
 

--- a/tutorials/sdk-android-flowjc-custom/sdk-android-flowjc-custom.md
+++ b/tutorials/sdk-android-flowjc-custom/sdk-android-flowjc-custom.md
@@ -36,46 +36,46 @@ Extend your flow class to the **`com.sap.cloud.mobile.flows.compose.flows.BaseFl
 
 1. Create a flow class named **`TestFlow`**:
 
-    ```Kotlin
-    class TestFlow(context: Context) : BaseFlow(context, "TestFlow") {
-            
-    }
-    ```
+   ```Kotlin
+   class TestFlow(context: Context) : BaseFlow(context, "TestFlow") {
+           
+   }
+   ```
 
 2. Implement the **`initialize`** function to create and add a customized flow step to your own flow:
 
-    ```Kotlin
-    override fun initialize() {
-        val step1 = SingleStep(context, "step_1") {
-            EulaScreen(
-                eulaContentLocale = localeState.value,
-                eulaScreenSettings = EulaScreenSettings(
-                    eulaUrl = "file:///android_res/raw/custom_eula.html",
-                    agreeButtonCaption = android.R.string.ok,
-                    disagreeButtonCaption = android.R.string.cancel
-                ),
-                agreeViewClickListener = {
-                    flowDone("step_1")
-                },
-                disagreeViewClickListener = {
-                    terminateFlowWithMessage("Custom flow cancelled.")
-                },
-                webViewClient = object : WebViewClient() {
-                    override fun shouldOverrideUrlLoading(
-                        view: WebView?,
-                        request: WebResourceRequest?
-                    ): Boolean =
-                        request?.url?.let { url ->
-                            SDKCustomTabsLauncher.launchCustomTabs(context, url.toString())
-                            true
-                        } ?: false
-                }
-            )
-        }
+   ```Kotlin
+   override fun initialize() {
+       val step1 = SingleStep(context, "step_1") {
+           EulaScreen(
+               eulaContentLocale = localeState.value,
+               eulaScreenSettings = EulaScreenSettings(
+                   eulaUrl = "file:///android_res/raw/custom_eula.html",
+                   agreeButtonCaption = android.R.string.ok,
+                   disagreeButtonCaption = android.R.string.cancel
+               ),
+               agreeViewClickListener = {
+                   flowDone("step_1")
+               },
+               disagreeViewClickListener = {
+                   terminateFlowWithMessage("Custom flow cancelled.")
+               },
+               webViewClient = object : WebViewClient() {
+                   override fun shouldOverrideUrlLoading(
+                       view: WebView?,
+                       request: WebResourceRequest?
+                   ): Boolean =
+                       request?.url?.let { url ->
+                           SDKCustomTabsLauncher.launchCustomTabs(context, url.toString())
+                           true
+                       } ?: false
+               }
+           )
+       }
 
-        addSingleStep(step1)
-    }
-    ```
+       addSingleStep(step1)
+   }
+   ```
 [ACCORDION-END]
 
 [ACCORDION-BEGIN [Step 2: ](Add flow steps to your flow)]
@@ -87,53 +87,53 @@ Extend your flow class to the **`com.sap.cloud.mobile.flows.compose.flows.BaseFl
 
     In the flow created in the first section, we implemented a customized flow step "step1" and added the step with **`addSingleStep`** function. Now we can create another flow named "SubFlow" and add it as a sub-flow for "TestFlow" that we created in the first section:
 
-    ```Kotlin
-    class SubFlow(context: Context) : BaseFlow(context, "SubFlow") {
-        override fun initialize() {
-            val step1 = SingleStep(context, "step_1") {
-                ConsentScreen(
-                    consentType = "CustomConsent",
-                    consentScreenSettings = ConsentScreenSettings(
-                        consentType = "CustomConsent",
-                        description = R.string.demo_custom_consent_description,
-                        agreeButtonCaption = android.R.string.ok,
-                        disagreeButtonCaption = android.R.string.cancel
-                    ),
-                    agreeButtonClickListener = {
-                        flowDone("step1_SubFlow")
-                    },
-                    disagreeButtonClickListener = {
-                        terminateFlowWithMessage("Cancel the custom flow.")
-                    }
-                )
-            }
+   ```Kotlin
+   class SubFlow(context: Context) : BaseFlow(context, "SubFlow") {
+       override fun initialize() {
+           val step1 = SingleStep(context, "step_1") {
+               ConsentScreen(
+                   consentType = "CustomConsent",
+                   consentScreenSettings = ConsentScreenSettings(
+                       consentType = "CustomConsent",
+                       description = R.string.demo_custom_consent_description,
+                       agreeButtonCaption = android.R.string.ok,
+                       disagreeButtonCaption = android.R.string.cancel
+                   ),
+                   agreeButtonClickListener = {
+                       flowDone("step1_SubFlow")
+                   },
+                   disagreeButtonClickListener = {
+                       terminateFlowWithMessage("Cancel the custom flow.")
+                   }
+               )
+           }
 
-            addSingleStep(step1)
-        }
-    }
-    class TestFlow(context: Context) : BaseFlow(context, "TestFlow") {
-        override fun initialize() {
-            val step1 = SingleStep(context, "step_1") {
-                ...
-            }
+           addSingleStep(step1)
+       }
+   }
+   class TestFlow(context: Context) : BaseFlow(context, "TestFlow") {
+       override fun initialize() {
+           val step1 = SingleStep(context, "step_1") {
+               ...
+           }
 
-            addSingleStep(step1)
-            addNestedFlow(SubFlow(context = context))
-        }
-    }
-    ```
+           addSingleStep(step1)
+           addNestedFlow(SubFlow(context = context))
+       }
+   }
+   ```
 
 2. When a flow starts, by default the app will navigate to the first step added in the **`initialize`** function. If the first step should be determined at runtime, you can override the **`start`** function of **`BaseFlow`** and define your own logic for the flow start step. To navigate among your steps, you can use the **`navigateTo`** function.
 
     There are two steps in the flow created in the first section. The first step includes a EULA screen, and the second step is a sub-flow with consent screen. If the first step must be excluded, you can use the following code to navigate to the sub-flow when the first step with EULA screen is excluded: 
 
-    ```Kotlin
-    override fun start(popRoute: String?) {
-        if(eulaExcluded) {
-            navigateTo("SubFlow", popRoute)
-        }     
-    }
-    ```
+   ```Kotlin
+   override fun start(popRoute: String?) {
+       if(eulaExcluded) {
+           navigateTo("SubFlow", popRoute)
+       }     
+   }
+   ```
 
 For more information, refer to [Write Your Own Flow](https://help.sap.com/doc/f53c64b93e5140918d676b927a3cd65b/Cloud/en-US/docs-en/guides/features/onboarding/android/compose-flows/CustomFlow.html).
 

--- a/tutorials/sdk-android-flows-custom/sdk-android-flows-custom.md
+++ b/tutorials/sdk-android-flows-custom/sdk-android-flows-custom.md
@@ -44,69 +44,69 @@ Besides the pre-defined flows described in the previous tutorials, the Flows Com
 
 4.  The following code snippet creates a simple flow step. First we create a layout XML file named **`fragment_step1`** for the UI part which includes a text view and a button.
 
-    ```XML
-    <?xml version="1.0" encoding="utf-8"?>
-    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:id="@+id/fragmentStepOne"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:context=".steps.CustomStepOne">
+   ```XML
+   <?xml version="1.0" encoding="utf-8"?>
+   <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:app="http://schemas.android.com/apk/res-auto"
+       xmlns:tools="http://schemas.android.com/tools"
+       android:id="@+id/fragmentStepOne"
+       android:layout_width="match_parent"
+       android:layout_height="match_parent"
+       tools:context=".steps.CustomStepOne">
 
-        <TextView
-            android:id="@+id/txtStepOne"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+       <TextView
+           android:id="@+id/txtStepOne"
+           android:layout_width="wrap_content"
+           android:layout_height="wrap_content"
+           app:layout_constraintBottom_toBottomOf="parent"
+           app:layout_constraintEnd_toEndOf="parent"
+           app:layout_constraintStart_toStartOf="parent"
+           app:layout_constraintTop_toTopOf="parent" />
 
-        <Button
-            android:id="@+id/btnOKStepOne"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            android:text="@android:string/ok"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/txtStepOne" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-    ```
+       <Button
+           android:id="@+id/btnOKStepOne"
+           android:layout_width="wrap_content"
+           android:layout_height="wrap_content"
+           android:layout_marginTop="24dp"
+           android:text="@android:string/ok"
+           app:layout_constraintEnd_toEndOf="parent"
+           app:layout_constraintStart_toStartOf="parent"
+           app:layout_constraintTop_toBottomOf="@+id/txtStepOne" />
+   </androidx.constraintlayout.widget.ConstraintLayout>
+   ```
 
-    Then we can create a flow step with the layout created above. In this flow step, we set a step name, create view with the layout file **`fragment_step1`** and add button click listener to notify step done.
+   Then we can create a flow step with the layout created above. In this flow step, we set a step name, create view with the layout file **`fragment_step1`** and add button click listener to notify step done.
 
-    ```Java
-    public class CustomStepOne extends FlowStepFragment {
-        @NotNull
-        @Override
-        public String getStepName() {
-            return "Step 1";
-        }
+   ```Java
+   public class CustomStepOne extends FlowStepFragment {
+       @NotNull
+       @Override
+       public String getStepName() {
+           return "Step 1";
+       }
 
-        @Nullable
-        @Override
-        public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
-                @Nullable Bundle savedInstanceState) {
-            return inflater.inflate(R.layout.fragment_step1, container, false);
-        }
+       @Nullable
+       @Override
+       public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+               @Nullable Bundle savedInstanceState) {
+           return inflater.inflate(R.layout.fragment_step1, container, false);
+       }
 
-        @Override
-        public void onActivityCreated(@org.jetbrains.annotations.Nullable Bundle savedInstanceState) {
-            super.onActivityCreated(savedInstanceState);
-            TextView txtStepOne = this.getView().findViewById(R.id.txtStepOne);
-            txtStepOne.setText(getStepName());
-            Button btnStepOne = this.getView().findViewById(R.id.btnOKStepOne);
-            btnStepOne.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    stepDone(R.id.fragmentStepOne);
-                }
-            });
-        }
-    }
-    ```
+       @Override
+       public void onActivityCreated(@org.jetbrains.annotations.Nullable Bundle savedInstanceState) {
+           super.onActivityCreated(savedInstanceState);
+           TextView txtStepOne = this.getView().findViewById(R.id.txtStepOne);
+           txtStepOne.setText(getStepName());
+           Button btnStepOne = this.getView().findViewById(R.id.btnOKStepOne);
+           btnStepOne.setOnClickListener(new View.OnClickListener() {
+               @Override
+               public void onClick(View v) {
+                   stepDone(R.id.fragmentStepOne);
+               }
+           });
+       }
+   }
+   ```
 
 [OPTION END]
 
@@ -122,62 +122,62 @@ Besides the pre-defined flows described in the previous tutorials, the Flows Com
 
 4.  The following code snippet creates a simple flow step. First we create a layout XML file named **`fragment_step1`** for the UI part which includes a text view and a button.
 
-    ```XML
-    <?xml version="1.0" encoding="utf-8"?>
-    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:id="@+id/fragmentStepOne"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:context=".steps.CustomStepOne">
+   ```XML
+   <?xml version="1.0" encoding="utf-8"?>
+   <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:app="http://schemas.android.com/apk/res-auto"
+       xmlns:tools="http://schemas.android.com/tools"
+       android:id="@+id/fragmentStepOne"
+       android:layout_width="match_parent"
+       android:layout_height="match_parent"
+       tools:context=".steps.CustomStepOne">
 
-        <TextView
-            android:id="@+id/txtStepOne"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+       <TextView
+           android:id="@+id/txtStepOne"
+           android:layout_width="wrap_content"
+           android:layout_height="wrap_content"
+           app:layout_constraintBottom_toBottomOf="parent"
+           app:layout_constraintEnd_toEndOf="parent"
+           app:layout_constraintStart_toStartOf="parent"
+           app:layout_constraintTop_toTopOf="parent" />
 
-        <Button
-            android:id="@+id/btnOKStepOne"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            android:text="@android:string/ok"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/txtStepOne" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-    ```
+       <Button
+           android:id="@+id/btnOKStepOne"
+           android:layout_width="wrap_content"
+           android:layout_height="wrap_content"
+           android:layout_marginTop="24dp"
+           android:text="@android:string/ok"
+           app:layout_constraintEnd_toEndOf="parent"
+           app:layout_constraintStart_toStartOf="parent"
+           app:layout_constraintTop_toBottomOf="@+id/txtStepOne" />
+   </androidx.constraintlayout.widget.ConstraintLayout>
+   ```
 
-    Then we can create a flow step with the layout created above. In this flow step, we set a step name, create view with the layout file **`fragment_step1`** and add button click listener to notify step done.
+   Then we can create a flow step with the layout created above. In this flow step, we set a step name, create view with the layout file **`fragment_step1`** and add button click listener to notify step done.
 
-    ```Kotlin
-    class CustomStepOne : FlowStepFragment() {
+   ```Kotlin
+   class CustomStepOne : FlowStepFragment() {
 
-        override fun getStepName(): String {
-            return "Step 1"
-        }
+       override fun getStepName(): String {
+           return "Step 1"
+       }
 
-        override fun onCreateView(
-            inflater: LayoutInflater, container: ViewGroup?,
-            savedInstanceState: Bundle?
-        ): View? {
-            return inflater.inflate(R.layout.fragment_step1, container, false)
-        }
+       override fun onCreateView(
+           inflater: LayoutInflater, container: ViewGroup?,
+           savedInstanceState: Bundle?
+       ): View? {
+           return inflater.inflate(R.layout.fragment_step1, container, false)
+       }
 
-        override fun onActivityCreated(savedInstanceState: Bundle?) {
-            super.onActivityCreated(savedInstanceState)
-            txtStepOne.text = getStepName()
-            btnOKStepOne.setOnClickListener { _ ->
-                stepDone(R.id.fragmentStepOne)
-            }
-        }
-    }
-    ```
+       override fun onActivityCreated(savedInstanceState: Bundle?) {
+           super.onActivityCreated(savedInstanceState)
+           txtStepOne.text = getStepName()
+           btnOKStepOne.setOnClickListener { _ ->
+               stepDone(R.id.fragmentStepOne)
+           }
+       }
+   }
+   ```
 
 [OPTION END]
 
@@ -196,25 +196,25 @@ Your own flow class must extend the **`com.sap.cloud.mobile.flowv2.core.Flow`** 
 
     You can add both pre-defined flow step and customized flow step to your flow with this method. Following is the sample code for a simple flow with a pre-defined EULA step and a customized step **`CustomStepOne`** we created in the first section.
 
-    ```Java
-    public class TestFlow extends Flow {
-        public TestFlow(@NotNull Application application) {
-            super(application);
-            addSingleStep(R.id.stepEula, JvmClassMappingKt.getKotlinClass(EulaFragment.class));
-            addSingleStep(R.id.fragmentStepOne, JvmClassMappingKt.getKotlinClass(CustomStepOne.class));
-        }
-    }
-    ```
+   ```Java
+   public class TestFlow extends Flow {
+       public TestFlow(@NotNull Application application) {
+           super(application);
+           addSingleStep(R.id.stepEula, JvmClassMappingKt.getKotlinClass(EulaFragment.class));
+           addSingleStep(R.id.fragmentStepOne, JvmClassMappingKt.getKotlinClass(CustomStepOne.class));
+       }
+   }
+   ```
 
-    Now you have created your first flow. Start the flow with the code below, and you can see the EULA screen and then the screen for "Step 1".
+   Now you have created your first flow. Start the flow with the code below, and you can see the EULA screen and then the screen for "Step 1".
 
-    ```Java
-       Flow testFlow = new TestFlow(application);
-       FlowContext flowContext = new FlowContextBuilder()
-               .setFlow(testFlow)
-               .build();
-       Flow.start(activity, flowContext);
-    ```
+   ```Java
+      Flow testFlow = new TestFlow(application);
+      FlowContext flowContext = new FlowContextBuilder()
+              .setFlow(testFlow)
+              .build();
+      Flow.start(activity, flowContext);
+   ```
 
 2.  A flow which only contains sequential steps cannot always meet your requirements. There may be some branching scenarios to navigate to different steps based on a certain condition. Following method controls the step navigation in a flow and client code can override this method to add its own logic:
 
@@ -224,85 +224,85 @@ Your own flow class must extend the **`com.sap.cloud.mobile.flowv2.core.Flow`** 
 
     Then create a **`ConditionFlow`** class to add all the three customized flow steps and override the **`getNextStep`** method.
 
-    ```Java
-    public class ConditionFlow extends Flow {
-        public static final String WHICH_STEP_KEY = "which.step";
+   ```Java
+   public class ConditionFlow extends Flow {
+       public static final String WHICH_STEP_KEY = "which.step";
 
-        public ConditionFlow(@NotNull Application application) {
-            super(application);
-            addSingleStep(R.id.fragmentStepOne, JvmClassMappingKt.getKotlinClass(CustomStepOne.class));
-            addSingleStep(R.id.fragmentStepTwo, JvmClassMappingKt.getKotlinClass(CustomStepTwo.class));
-            addSingleStep(R.id.fragmentStepThree, JvmClassMappingKt.getKotlinClass(CustomStepThree.class));
-        }
+       public ConditionFlow(@NotNull Application application) {
+           super(application);
+           addSingleStep(R.id.fragmentStepOne, JvmClassMappingKt.getKotlinClass(CustomStepOne.class));
+           addSingleStep(R.id.fragmentStepTwo, JvmClassMappingKt.getKotlinClass(CustomStepTwo.class));
+           addSingleStep(R.id.fragmentStepThree, JvmClassMappingKt.getKotlinClass(CustomStepThree.class));
+       }
 
-        @Nullable
-        @Override
-        public Object getNextStep(int currentStepId, @NotNull BusinessDataMap businessDataMap,
-                @NotNull Continuation<? super Pair<Integer, ? extends KClass<?>>> $completion) {
-            int whichStep = this.getStepNum(businessDataMap);
-            if (currentStepId == R.id.fragmentStepOne) {
-                if (whichStep == 1) {
-                    return new Pair(R.id.fragmentStepThree,
-                            JvmClassMappingKt.getKotlinClass(CustomStepThree.class));
-                } else {
-                   return new Pair(R.id.fragmentStepTwo,
-                            JvmClassMappingKt.getKotlinClass(CustomStepTwo.class));
-                }
-            } else if (currentStepId == R.id.fragmentStepTwo || currentStepId == R.id.fragmentStepThree) {
-                return new Pair(FlowConstants.FLOW_STATUS_END, null);
-            }
-            return super.getNextStep(currentStepId, businessDataMap, $completion);
-        }
+       @Nullable
+       @Override
+       public Object getNextStep(int currentStepId, @NotNull BusinessDataMap businessDataMap,
+               @NotNull Continuation<? super Pair<Integer, ? extends KClass<?>>> $completion) {
+           int whichStep = this.getStepNum(businessDataMap);
+           if (currentStepId == R.id.fragmentStepOne) {
+               if (whichStep == 1) {
+                   return new Pair(R.id.fragmentStepThree,
+                           JvmClassMappingKt.getKotlinClass(CustomStepThree.class));
+               } else {
+                  return new Pair(R.id.fragmentStepTwo,
+                           JvmClassMappingKt.getKotlinClass(CustomStepTwo.class));
+               }
+           } else if (currentStepId == R.id.fragmentStepTwo || currentStepId == R.id.fragmentStepThree) {
+               return new Pair(FlowConstants.FLOW_STATUS_END, null);
+           }
+           return super.getNextStep(currentStepId, businessDataMap, $completion);
+       }
 
-        private int getStepNum(BusinessDataMap businessDataMap) {
-            Object whichStep = businessDataMap.getBusinessData(WHICH_STEP_KEY);
-            if(whichStep == null) {
-                return 0;
-            } else {
-                return  ((Integer) whichStep).intValue();
-            }
-        }
-    }
-    ```
+       private int getStepNum(BusinessDataMap businessDataMap) {
+           Object whichStep = businessDataMap.getBusinessData(WHICH_STEP_KEY);
+           if(whichStep == null) {
+               return 0;
+           } else {
+               return  ((Integer) whichStep).intValue();
+           }
+       }
+   }
+   ```
 
-    The navigation for this flow is when current step is "Step 1", the client code will check the data saved in the **`BusinessDataMap`** instance and navigate to "Step 3" if the value for the key **`WHICH_STEP_KEY`** is explicitly set to 1, otherwise navigate to "Step 2". And when current step is "Step 2" or "Step 3", current step is the last step of the flow. For other cases, the navigation logic is from the parent class.
+   The navigation for this flow is when current step is "Step 1", the client code will check the data saved in the **`BusinessDataMap`** instance and navigate to "Step 3" if the value for the key **`WHICH_STEP_KEY`** is explicitly set to 1, otherwise navigate to "Step 2". And when current step is "Step 2" or "Step 3", current step is the last step of the flow. For other cases, the navigation logic is from the parent class.
 
-    Now make some modification to "Step 1" to make the **`ConditionFlow`** work. First add one more button "Step 3" to the layout XML file.
+   Now make some modification to "Step 1" to make the **`ConditionFlow`** work. First add one more button "Step 3" to the layout XML file.
 
-    ```XML
-    <Button
-        android:id="@+id/btnConditionStepTest"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:text="Step 3"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/btnOKStepOne" />
-    ```
+   ```XML
+   <Button
+       android:id="@+id/btnConditionStepTest"
+       android:layout_width="wrap_content"
+       android:layout_height="wrap_content"
+       android:layout_marginTop="16dp"
+       android:text="Step 3"
+       app:layout_constraintEnd_toEndOf="parent"
+       app:layout_constraintStart_toStartOf="parent"
+       app:layout_constraintTop_toBottomOf="@+id/btnOKStepOne" />
+   ```
 
-    Then add button click logic to save value 1 for the key **`WHICH_STEP_KEY`** to the **`BusinessDataMap`** instance, so when this new button is clicked, the flow will navigate to "Step 3", otherwise navigate to "Step 2".
+   Then add button click logic to save value 1 for the key **`WHICH_STEP_KEY`** to the **`BusinessDataMap`** instance, so when this new button is clicked, the flow will navigate to "Step 3", otherwise navigate to "Step 2".
 
-    ```Java
-    Button btnStepTest = this.getView().findViewById(R.id.btnConditionStepTest);
-    btnStepTest.setOnClickListener(new View.OnClickListener() {
-        @Override
-        public void onClick(View v) {
-            getFlowViewModel().getBusinessData().saveBusinessData(ConditionFlow.WHICH_STEP_KEY, 1, true);
-            stepDone(R.id.fragmentStepOne);
-        }
-    });
-    ```
+   ```Java
+   Button btnStepTest = this.getView().findViewById(R.id.btnConditionStepTest);
+   btnStepTest.setOnClickListener(new View.OnClickListener() {
+       @Override
+       public void onClick(View v) {
+           getFlowViewModel().getBusinessData().saveBusinessData(ConditionFlow.WHICH_STEP_KEY, 1, true);
+           stepDone(R.id.fragmentStepOne);
+       }
+   });
+   ```
 
-    Now start the flow with following code. The first screen of the flow is "Step 1" which contains two buttons. If the OK button is clicked, the screen "Step 2" is displayed and if the "Step 3" button is clicked, the screen "Step 3" is displayed. Then click the button on "Step 2" or "Step 3", the flow is finished.
+   Now start the flow with following code. The first screen of the flow is "Step 1" which contains two buttons. If the OK button is clicked, the screen "Step 2" is displayed and if the "Step 3" button is clicked, the screen "Step 3" is displayed. Then click the button on "Step 2" or "Step 3", the flow is finished.
 
-    ```Java
-    Flow testFlow = new ConditionFlow(application);
-    FlowContext flowContext = new FlowContextBuilder()
-             .setFlow(testFlow)
-             .build();
-    Flow.start(activity, flowContext);
-    ```
+   ```Java
+   Flow testFlow = new ConditionFlow(application);
+   FlowContext flowContext = new FlowContextBuilder()
+            .setFlow(testFlow)
+            .build();
+   Flow.start(activity, flowContext);
+   ```
 
 3.  As mentioned in the beginning, besides the single flow step, a flow can also include sub-flows. Following method allows client code to add a sub-flow.
 
@@ -310,15 +310,15 @@ Your own flow class must extend the **`com.sap.cloud.mobile.flowv2.core.Flow`** 
 
     The following sample code creates a flow with a pre-defined flow step and a sub-flow.
 
-    ```Java
-    public class NestedFlow extends Flow {
-        public NestedFlow(@NotNull Application application) {
-            super(application);
-            addSingleStep(R.id.stepEula, JvmClassMappingKt.getKotlinClass(EulaFragment.class));
-            addNestedFlow(new ConditionFlow(application));
-        }
-    }
-    ```
+   ```Java
+   public class NestedFlow extends Flow {
+       public NestedFlow(@NotNull Application application) {
+           super(application);
+           addSingleStep(R.id.stepEula, JvmClassMappingKt.getKotlinClass(EulaFragment.class));
+           addNestedFlow(new ConditionFlow(application));
+       }
+   }
+   ```
 
 4.  Client code can insert logic at different stage of the flow by overriding the following methods:
 
@@ -342,22 +342,22 @@ Your own flow class must extend the **`com.sap.cloud.mobile.flowv2.core.Flow`** 
 
     You can add both pre-defined flow step and customized flow step to your flow with this method. Following is the sample code for a simple flow with a pre-defined EULA step and a customized step **`CustomStepOne`** we created in the first section.
 
-    ```Kotlin
-    open class TestFlow(private val application: Application) : Flow(application) {
-        init {
-            addSingleStep(R.id.stepEula, EulaFragment::class)
-            addSingleStep(R.id.fragmentStepOne, CustomStepOne::class)
-        }
-    }
-    ```
+   ```Kotlin
+   open class TestFlow(private val application: Application) : Flow(application) {
+       init {
+           addSingleStep(R.id.stepEula, EulaFragment::class)
+           addSingleStep(R.id.fragmentStepOne, CustomStepOne::class)
+       }
+   }
+   ```
 
-    Now you have created your first flow. Start the flow with the code below, and you can see the EULA screen and then the screen for "Step 1".
+   Now you have created your first flow. Start the flow with the code below, and you can see the EULA screen and then the screen for "Step 1".
 
-    ```Kotlin
-    val testFlow = TestFlow(application)
-    val flowContext = FlowContext(flow = testFlow)
-    Flow.start(activity, flowContext)
-    ```
+   ```Kotlin
+   val testFlow = TestFlow(application)
+   val flowContext = FlowContext(flow = testFlow)
+   Flow.start(activity, flowContext)
+   ```
 
 2.  A flow which only contains sequential steps cannot always meet your requirements. There may be some branching scenarios to navigate to different steps based on a certain condition. Following method controls the step navigation in a flow and client code can override this method to add its own logic:
 
@@ -367,71 +367,71 @@ Your own flow class must extend the **`com.sap.cloud.mobile.flowv2.core.Flow`** 
 
     Then create a **`ConditionFlow`** class to add all the three customized flow steps and override the **`getNextStep`** method.
 
-    ```Kotlin
-    class ConditionFlow(private val application: Application) : Flow(application) {
-        init {
-            addSingleStep(R.id.fragmentStepOne, CustomStepOne::class)
-            addSingleStep(R.id.fragmentStepTwo, CustomStepTwo::class)
-            addSingleStep(R.id.fragmentStepThree, CustomStepThree::class)
-        }
+   ```Kotlin
+   class ConditionFlow(private val application: Application) : Flow(application) {
+       init {
+           addSingleStep(R.id.fragmentStepOne, CustomStepOne::class)
+           addSingleStep(R.id.fragmentStepTwo, CustomStepTwo::class)
+           addSingleStep(R.id.fragmentStepThree, CustomStepThree::class)
+       }
 
-        override suspend fun getNextStep(
-            currentStepId: Int,
-            businessData: BusinessDataMap
-        ): Pair<Int, KClass<*>?>? {
-            val whichStep = businessData.getBusinessData(WHICH_STEP_KEY) ?: 0
-            return when (currentStepId) {
-                R.id.fragmentStepOne ->
-                    return if (whichStep == 1) Pair(
-                        R.id.fragmentStepThree,
-                        CustomStepThree::class
-                    ) else Pair(R.id.fragmentStepTwo, CustomStepTwo::class)
-                in listOf(
-                    R.id.fragmentStepTwo,
-                    R.id.fragmentStepThree
-                ) -> Pair(FlowConstants.FLOW_STATUS_END, null)
-                else -> super.getNextStep(currentStepId, businessData)
-            }
-        }
+       override suspend fun getNextStep(
+           currentStepId: Int,
+           businessData: BusinessDataMap
+       ): Pair<Int, KClass<*>?>? {
+           val whichStep = businessData.getBusinessData(WHICH_STEP_KEY) ?: 0
+           return when (currentStepId) {
+               R.id.fragmentStepOne ->
+                   return if (whichStep == 1) Pair(
+                       R.id.fragmentStepThree,
+                       CustomStepThree::class
+                   ) else Pair(R.id.fragmentStepTwo, CustomStepTwo::class)
+               in listOf(
+                   R.id.fragmentStepTwo,
+                   R.id.fragmentStepThree
+               ) -> Pair(FlowConstants.FLOW_STATUS_END, null)
+               else -> super.getNextStep(currentStepId, businessData)
+           }
+       }
 
-        companion object {
-            const val WHICH_STEP_KEY = "which.step"
-        }
-    }
-    ```
+       companion object {
+           const val WHICH_STEP_KEY = "which.step"
+       }
+   }
+   ```
 
-    The navigation for this flow is when current step is "Step 1", the client code will check the data saved in the **`BusinessDataMap`** instance and navigate to "Step 3" if the value for the key **`WHICH_STEP_KEY`** is explicitly set to 1, otherwise navigate to "Step 2". And when current step is "Step 2" or "Step 3", current step is the last step of the flow. For other cases, the navigation logic is from the parent class.
+   The navigation for this flow is when current step is "Step 1", the client code will check the data saved in the **`BusinessDataMap`** instance and navigate to "Step 3" if the value for the key **`WHICH_STEP_KEY`** is explicitly set to 1, otherwise navigate to "Step 2". And when current step is "Step 2" or "Step 3", current step is the last step of the flow. For other cases, the navigation logic is from the parent class.
 
-    Now make some modification to "Step 1" to make the **`ConditionFlow`** work. First add one more button "Step 3" to the layout XML file.
+   Now make some modification to "Step 1" to make the **`ConditionFlow`** work. First add one more button "Step 3" to the layout XML file.
 
-    ```XML
-    <Button
-        android:id="@+id/btnConditionStepTest"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:text="Step 3"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/btnOKStepOne" />
-    ```
+   ```XML
+   <Button
+       android:id="@+id/btnConditionStepTest"
+       android:layout_width="wrap_content"
+       android:layout_height="wrap_content"
+       android:layout_marginTop="16dp"
+       android:text="Step 3"
+       app:layout_constraintEnd_toEndOf="parent"
+       app:layout_constraintStart_toStartOf="parent"
+       app:layout_constraintTop_toBottomOf="@+id/btnOKStepOne" />
+   ```
 
-    Then add button click logic to save value 1 for the key **`WHICH_STEP_KEY`** to the **`BusinessDataMap`** instance, so when this new button is clicked, the flow will navigate to "Step 3", otherwise navigate to "Step 2".
+   Then add button click logic to save value 1 for the key **`WHICH_STEP_KEY`** to the **`BusinessDataMap`** instance, so when this new button is clicked, the flow will navigate to "Step 3", otherwise navigate to "Step 2".
 
-    ```Kotlin
-    btnConditionStepTest.setOnClickListener { _ ->
-        flowViewModel.businessData.saveBusinessData(ConditionFlow.WHICH_STEP_KEY, 1)
-        stepDone(R.id.fragmentStepOne)
-    }
-    ```
+   ```Kotlin
+   btnConditionStepTest.setOnClickListener { _ ->
+       flowViewModel.businessData.saveBusinessData(ConditionFlow.WHICH_STEP_KEY, 1)
+       stepDone(R.id.fragmentStepOne)
+   }
+   ```
 
-    Now start the flow with following code. The first screen of the flow is "Step 1" which contains two buttons. If the OK button is clicked, the screen "Step 2" is displayed and if the "Step 3" button is clicked, the screen "Step 3" is displayed. Then click the button on "Step 2" or "Step 3", the flow is finished.
+   Now start the flow with following code. The first screen of the flow is "Step 1" which contains two buttons. If the OK button is clicked, the screen "Step 2" is displayed and if the "Step 3" button is clicked, the screen "Step 3" is displayed. Then click the button on "Step 2" or "Step 3", the flow is finished.
 
-    ```Kotlin
-    val testFlow = ConditionFlow(application)
-    val flowContext = FlowContext(flow = testFlow)
-    Flow.start(activity, flowContext)
-    ```
+   ```Kotlin
+   val testFlow = ConditionFlow(application)
+   val flowContext = FlowContext(flow = testFlow)
+   Flow.start(activity, flowContext)
+   ```
 
 3.  As mentioned in the beginning, besides the single flow step, a flow can also include sub-flows. Following method allows client code to add a sub-flow.
 
@@ -439,14 +439,14 @@ Your own flow class must extend the **`com.sap.cloud.mobile.flowv2.core.Flow`** 
 
     The following sample code creates a flow with a pre-defined flow step and a sub-flow.
 
-    ```Kotlin
-    class NestedFlow(private val application: Application) : Flow(application) {
-        init {
-            addSingleStep(R.id.stepEula, EulaFragment::class)
-            addNestedFlow(ConditionFlow(application))
-        }
-    }
-    ```
+   ```Kotlin
+   class NestedFlow(private val application: Application) : Flow(application) {
+       init {
+           addSingleStep(R.id.stepEula, EulaFragment::class)
+           addNestedFlow(ConditionFlow(application))
+       }
+   }
+   ```
 
 4.  Client code can insert logic at different stage of the flow by overriding the following methods:
 

--- a/tutorials/sdk-android-flows-onboarding/sdk-android-flows-onboarding.md
+++ b/tutorials/sdk-android-flows-onboarding/sdk-android-flows-onboarding.md
@@ -40,38 +40,38 @@ The visibility and the content of each screen will vary depending on the differe
 
 1.  By default, the first screen of the onboarding flow is the EULA screen. This screen allows users to review and agree to the end user license agreement. To exclude this screen, create a **`FlowOptions`** instance that overrides the **`excludeOnBoardingEulaScreen`** function to return the value **`true`** and set this **`FlowOptions`** instance for the **`FlowContext`** instance to start the onboarding flow.
 
-    ```Java
-    FlowContext flowContext = new FlowContextBuilder()
-                .setApplication(appConfig)
-                .setFlowOptions(new FlowOptions(){
-                    @Override
-                    public boolean excludeOnBoardingEulaScreen() {
-                        return true;
-                    }
-                }).build();
-    Flow.start(this, flowContext);
-    ```
+   ```Java
+   FlowContext flowContext = new FlowContextBuilder()
+               .setApplication(appConfig)
+               .setFlowOptions(new FlowOptions(){
+                   @Override
+                   public boolean excludeOnBoardingEulaScreen() {
+                       return true;
+                   }
+               }).build();
+   Flow.start(this, flowContext);
+   ```
 
-    Notice that if the EULA screen is excluded, it will be the responsibility of the client code to handle the end user license agreement.
+   Notice that if the EULA screen is excluded, it will be the responsibility of the client code to handle the end user license agreement.
 
 2.  If the **`AppConfig`** instance in **`FlowContext`** does not provide the authentication info or host for the mobile application, the activation screen will be displayed to get the complete **`AppConfig`** from either the `Discovery Service` or `QR code scanning`. By default, the activation screen will be displayed for  both activation methods for the user to select. The client code can customize the screen to display only one of these methods.
 
     Create a **`FlowOptions`** instance that overrides the **`activationOption`** function to return the **`ActivationOption`**, **`ActivationOption.DS_ONLY`** value to display the `Discovery Service` method only, and **`ActivationOption.QR_ONLY`** to display the `QR code scanning` method only. Using the code snippet below, the activation screen will only display the option for scanning a QR code.
 
-    ```Java
-    FlowContext flowContext = new FlowContextBuilder()
-                .setApplication(new AppConfig.Builder().applicationId("app_id").build())
-                .setFlowOptions(new FlowOptions(){
-                    @NotNull
-                    @Override
-                    public ActivationOption activationOption() {
-                        return ActivationOption.QR_ONLY;
-                    }
-                }).build();
-    Flow.start(this, flowContext);
-    ```
+   ```Java
+   FlowContext flowContext = new FlowContextBuilder()
+               .setApplication(new AppConfig.Builder().applicationId("app_id").build())
+               .setFlowOptions(new FlowOptions(){
+                   @NotNull
+                   @Override
+                   public ActivationOption activationOption() {
+                       return ActivationOption.QR_ONLY;
+                   }
+               }).build();
+   Flow.start(this, flowContext);
+   ```
 
-    Notice that if the **`AppConfig`** instance contains complete information, the onboarding flow will skip the activation screen and go directly to the authentication step.
+   Notice that if the **`AppConfig`** instance contains complete information, the onboarding flow will skip the activation screen and go directly to the authentication step.
 
 3.  After getting the complete application configuration, the onboarding flow will display different authentication screens based on the authentication type defined for the application. For example, a screen with user input for `User Name` and `Password` properties will be displayed if the authentication type is `Basic`. If the authentication type is `SAML`, the screen will redirect to a web page for user login. The logic to decide which authentication screen to display is built into the onboarding flow and client code cannot change it.
 
@@ -79,33 +79,33 @@ The visibility and the content of each screen will vary depending on the differe
 
     Also, the usage consent screen will be skipped if usage reporting is not enabled and the crash report screen will be skipped if crash reporting is not enabled. Otherwise the screens will be displayed in the  onboarding flow, the and client code cannot alter this fact. To enable the usage reporting and crash reporting services, the client code needs start them using the **`SDKInitializer`** class.
 
-    ```Java
-    List<MobileService> services = new ArrayList<>();
-    services.add(new UsageService());
-    services.add(new CrashService());
+   ```Java
+   List<MobileService> services = new ArrayList<>();
+   services.add(new UsageService());
+   services.add(new CrashService());
 
-    SDKInitializer.INSTANCE.start(this, services.toArray(new MobileService[0]), null);
-    ```
+   SDKInitializer.INSTANCE.start(this, services.toArray(new MobileService[0]), null);
+   ```
 
 5.  Besides the options to include or exclude a step, you can set the client code to customize screens using its  **`ScreenSettings`**, including the title, description and button text for all screens. For some specific screens, such as EULA screen, the client code can specify its own URL for the EULA file. See [Onboarding Screens](https://help.sap.com/doc/f53c64b93e5140918d676b927a3cd65b/Cloud/en-US/docs-en/guides/features/onboarding/android/fiori-screens/introduction.html) in the help documentation for information on the detailed settings for each screen in the onboarding process.
 
     To have the customized screen settings take effect in the onboarding flow, set the list of **`ScreenSettings`** for the **`FlowContext`** instance.
 
-    ```Java
-    List settingsList = new ArrayList<ScreenSettings>();
-    EulaScreenSettings eulaScreenSettings = new EulaScreenSettings.Builder().setEulaUrl(
-            "file:///android_asset/my_eula.html").build();
-    settingsList.add(eulaScreenSettings);
-    SetPasscodeScreenSettings setPasscodeScreenSettings =
-            new SetPasscodeScreenSettings.Builder().setInstruction("Set my passcode").build();
-    settingsList.add(setPasscodeScreenSettings);
+   ```Java
+   List settingsList = new ArrayList<ScreenSettings>();
+   EulaScreenSettings eulaScreenSettings = new EulaScreenSettings.Builder().setEulaUrl(
+           "file:///android_asset/my_eula.html").build();
+   settingsList.add(eulaScreenSettings);
+   SetPasscodeScreenSettings setPasscodeScreenSettings =
+           new SetPasscodeScreenSettings.Builder().setInstruction("Set my passcode").build();
+   settingsList.add(setPasscodeScreenSettings);
 
-    FlowContext flowContext = new FlowContextBuilder()
-                .setApplication(new AppConfig.Builder().applicationId("app_id").build())
-                .setScreenSettings(settingsList)
-                .build();
-    Flow.start(this, flowContext);
-    ```
+   FlowContext flowContext = new FlowContextBuilder()
+               .setApplication(new AppConfig.Builder().applicationId("app_id").build())
+               .setScreenSettings(settingsList)
+               .build();
+   Flow.start(this, flowContext);
+   ```
 
 [OPTION END]
 
@@ -113,35 +113,35 @@ The visibility and the content of each screen will vary depending on the differe
 
 1.  By default, the first screen of the onboarding flow is the EULA screen. This screen allows users to review and agree to the end user license agreement. To exclude this screen, set the value of **`excludeEula`** parameter to **`true`** for the **`FlowOptions`** instance and set this **`FlowOptions`** instance for the **`FlowContext`** instance to start the onboarding flow.
 
-    ```Kotlin
-    val flowContext =
-                FlowContextBuilder()
-                        .setApplication(appConfig)
-                        .setFlowOptions(FlowOptions(
-                                excludeEula = true
-                        ))
-                        .build()
-    Flow.start(activity, flowContext)
-    ```
+   ```Kotlin
+   val flowContext =
+               FlowContextBuilder()
+                       .setApplication(appConfig)
+                       .setFlowOptions(FlowOptions(
+                               excludeEula = true
+                       ))
+                       .build()
+   Flow.start(activity, flowContext)
+   ```
 
-    Notice that if the EULA screen is excluded, it will be the responsibility of the client code to handle the end user license agreement.
+   Notice that if the EULA screen is excluded, it will be the responsibility of the client code to handle the end user license agreement.
 
 2.  If the **`AppConfig`** instance in **`FlowContext`** does not provide the authentication info or host for the mobile application, the activation screen will be displayed to get the complete **`AppConfig`** from either the `Discovery Service` or `QR code scanning`. By default, the activation screen will be displayed for  both activation methods for the user to select. The client code can customize the screen to display only one of these methods.
 
     Create a **`FlowOptions`** instance and set the value for **`activationOption`** parameter, **`ActivationOption.DS_ONLY`** value to display the `Discovery Service` method only and **`ActivationOption.QR_ONLY`** value to display the `QR code scanning` method only. Using the code snippet below, the activation screen will only display the option for scanning a QR code.
 
-    ```Kotlin
-    val flowContext =
-                FlowContextBuilder()
-                        .setApplication(AppConfig.Builder().applicationId("app_id").build())
-                        .setFlowOptions(FlowOptions(
-                                activationOption = ActivationOption.QR_ONLY
-                        ))
-                        .build()
-    Flow.start(activity, flowContext)
-    ```
+   ```Kotlin
+   val flowContext =
+               FlowContextBuilder()
+                       .setApplication(AppConfig.Builder().applicationId("app_id").build())
+                       .setFlowOptions(FlowOptions(
+                               activationOption = ActivationOption.QR_ONLY
+                       ))
+                       .build()
+   Flow.start(activity, flowContext)
+   ```
 
-    Notice that if the **`AppConfig`** instance contains complete information, the onboarding flow will skip the activation screen and go directly to the authentication step.
+   Notice that if the **`AppConfig`** instance contains complete information, the onboarding flow will skip the activation screen and go directly to the authentication step.
 
 
 3.  After getting the complete application configuration, the onboarding flow will display different authentication screens based on the authentication type defined for the application. For example, a screen with user input for `User Name` and `Password` properties will be displayed if the authentication type is `Basic`. If the authentication type is `SAML`, the screen will redirect to a web page for user login. The logic to decide which authentication screen to display is built into the onboarding flow and client code cannot change it.
@@ -150,32 +150,32 @@ The visibility and the content of each screen will vary depending on the differe
 
     Also, the usage consent screen will be skipped if usage reporting is not enabled and the crash report screen will be skipped if crash reporting is not enabled. Otherwise the screens will be displayed in the  onboarding flow, the and client code cannot alter this fact. To enable the usage reporting and crash reporting services, the client code needs start them using the **`SDKInitializer`** class.
 
-    ```Kotlin
-    val services = mutableListOf<MobileService>()
-    services.add(UsageService())
-    services.add(CrashService())
+   ```Kotlin
+   val services = mutableListOf<MobileService>()
+   services.add(UsageService())
+   services.add(CrashService())
 
-    SDKInitializer.start(this, * services.toTypedArray())
-    ```
+   SDKInitializer.start(this, * services.toTypedArray())
+   ```
 
 5.  Besides the options to include or exclude a step, you can set the client code to customize screens using its  **`ScreenSettings`**, including the title, description and button text for all screens. For some specific screens, such as EULA screen, the client code can specify its own URL for the EULA file. See [Onboarding Screens](https://help.sap.com/doc/f53c64b93e5140918d676b927a3cd65b/Cloud/en-US/docs-en/guides/features/onboarding/android/fiori-screens/introduction.html) in the help documentation for information on the detailed settings for each screen in the onboarding process.
 
     To have the customized screen settings take effect in the onboarding flow, set the list of **`ScreenSettings`** for the **`FlowContext`** instance.
 
-    ```Kotlin
-    val eulaSettings = EulaScreenSettings.Builder()
-                .setEulaUrl("file:///android_asset/my_eula.html")
-                .build()
-    val setPasscodeScreenSettings = SetPasscodeScreenSettings.Builder()
-                .setInstruction("Set my passcode")
-                .build()
-    val flowContext =
-                FlowContextBuilder()
-                        .setApplication(AppConfig.Builder().applicationId("app_id").build())
-                        .setScreenSettings(listOf(eulaSettings, setPasscodeScreenSettings))
-                        .build()
-    Flow.start(activity, flowContext)
-    ```
+   ```Kotlin
+   val eulaSettings = EulaScreenSettings.Builder()
+               .setEulaUrl("file:///android_asset/my_eula.html")
+               .build()
+   val setPasscodeScreenSettings = SetPasscodeScreenSettings.Builder()
+               .setInstruction("Set my passcode")
+               .build()
+   val flowContext =
+               FlowContextBuilder()
+                       .setApplication(AppConfig.Builder().applicationId("app_id").build())
+                       .setScreenSettings(listOf(eulaSettings, setPasscodeScreenSettings))
+                       .build()
+   Flow.start(activity, flowContext)
+   ```
 
 [OPTION END]
 
@@ -205,18 +205,18 @@ In this section, we explain the onboarding-related callbacks in **`FlowStateList
 
 6.  Besides the callbacks implemented in the **`WizardFlowStateListener`** class, the **`OkHttpClientReady`** method is also useful if you want to add an HTTP header into the **`OkHttpClient`** instance. Before authentication, the **`OkHttpClient`** instance will be ready and sent to the client code using `onOkHttpClientReady`. To add your own HTTP header, override the **`onOkHttpClientReady`** method in your flow state listener.
 
-    ```Java
-    @Override
-    public void onOkHttpClientReady(@NotNull OkHttpClient httpClient) {
-        OkHttpClient newClient = FlowUtilKt.addUniqueInterceptor(httpClient, chain -> {
-            Request request = chain.request();
-            Request newRequest = request.newBuilder()
-                    .header("my_header", "my_header_value")
-                    .build();
-            return chain.proceed(newRequest);
-        });
-    }
-    ```
+   ```Java
+   @Override
+   public void onOkHttpClientReady(@NotNull OkHttpClient httpClient) {
+       OkHttpClient newClient = FlowUtilKt.addUniqueInterceptor(httpClient, chain -> {
+           Request request = chain.request();
+           Request newRequest = request.newBuilder()
+                   .header("my_header", "my_header_value")
+                   .build();
+           return chain.proceed(newRequest);
+       });
+   }
+   ```
 
 [OPTION END]
 
@@ -239,19 +239,19 @@ In this section, we explain the onboarding-related callbacks in **`FlowStateList
 
 6.  Besides the callbacks implemented in the **`WizardFlowStateListener`** class, the **`OkHttpClientReady`** method is also useful if you want to add an HTTP header into the **`onOkHttpClient`** instance. Before authentication, the **`OkHttpClient`** instance will be ready and sent to the client code using `onOkHttpClientReady`. To add your own HTTP header, override the **`OkHttpClientReady`** method in your flow state listener.
 
-    ```Kotlin
-    override fun onOkHttpClientReady(httpClient: OkHttpClient) {
-        httpClient.addUniqueInterceptor( object: Interceptor {
-            override fun intercept(chain: Interceptor.Chain): Response {
-                val request: Request = chain.request()
-                val newRequest = request.newBuilder()
-                    .header("my_header", "my_header_value")
-                    .build()
-                return chain.proceed(newRequest)
-            }
-        })
-    }
-    ```
+   ```Kotlin
+   override fun onOkHttpClientReady(httpClient: OkHttpClient) {
+       httpClient.addUniqueInterceptor( object: Interceptor {
+           override fun intercept(chain: Interceptor.Chain): Response {
+               val request: Request = chain.request()
+               val newRequest = request.newBuilder()
+                   .header("my_header", "my_header_value")
+                   .build()
+               return chain.proceed(newRequest)
+           }
+       })
+   }
+   ```
 
 [OPTION END]
 
@@ -279,15 +279,15 @@ This section provides some sample implementations for the methods in the **`Flow
 
     The first two methods allow you to add additional rules for passcode policy and the last method is for you to add your own validation logic in additional to the rules defined in the passcode policy. For example, when the passcode policy allows special characters, you can still add the logic to disable certain special characters. For instance, the sample code below prevents the user from being able to use "@" as one of the possible special character:
 
-    ```Java
-    @Override
-    public boolean validatePasscode(@NotNull char[] code) {
-        if(code.toString().contains("@")) {
-            return false;
-        }
-        return super.validatePasscode(code);
-    }
-    ```
+   ```Java
+   @Override
+   public boolean validatePasscode(@NotNull char[] code) {
+       if(code.toString().contains("@")) {
+           return false;
+       }
+       return super.validatePasscode(code);
+   }
+   ```
 
 2.  The **`FlowActionHandler`** provides two methods related to the QR code:
 
@@ -299,20 +299,20 @@ This section provides some sample implementations for the methods in the **`Flow
 
     For example, you can specify that the QR code must contain some particular properties:
 
-    ```Java
-    @NotNull
-    @Override
-    public ServiceResult<Boolean> validateBarcode(@NotNull String barcode) {
-        if (barcode != null && barcode.contains("AppId") && barcode.contains("ClientId")
-                && barcode.contains("AuthorizationEndpointUrl")
-                && barcode.contains("ServerUrl") && barcode.contains("RedirectUrl")
-                && barcode.contains("TokenUrl")) {
-            return new ServiceResult.SUCCESS(true);
-        } else {
-            return new ServiceResult.FAILURE("");
-        }
-    }
-    ```
+   ```Java
+   @NotNull
+   @Override
+   public ServiceResult<Boolean> validateBarcode(@NotNull String barcode) {
+       if (barcode != null && barcode.contains("AppId") && barcode.contains("ClientId")
+               && barcode.contains("AuthorizationEndpointUrl")
+               && barcode.contains("ServerUrl") && barcode.contains("RedirectUrl")
+               && barcode.contains("TokenUrl")) {
+           return new ServiceResult.SUCCESS(true);
+       } else {
+           return new ServiceResult.FAILURE("");
+       }
+   }
+   ```
 
 3.  The **`FlowActionHandler`** provides two methods related to the certificate handling:
 
@@ -324,13 +324,13 @@ This section provides some sample implementations for the methods in the **`Flow
 
     For example, you can create a **`SslClientAuth`** instance using a **`ChooseCertificateProvider`** instance to pop up a dialog for user to choose a certificate:
 
-    ```Java
-    @Override
-    public SslClientAuth onCertificateSslClientAuthPrepared() {
-        ChooseCertificateProvider chooseCertificateProvider = new ChooseCertificateProvider();
-        return new SslClientAuth(chooseCertificateProvider);
-    }
-    ```
+   ```Java
+   @Override
+   public SslClientAuth onCertificateSslClientAuthPrepared() {
+       ChooseCertificateProvider chooseCertificateProvider = new ChooseCertificateProvider();
+       return new SslClientAuth(chooseCertificateProvider);
+   }
+   ```
 
 4.  The **`FlowActionHandler`** provides two methods for user name and email obfuscation when displaying the information on the sign-in screen:
 
@@ -340,26 +340,26 @@ This section provides some sample implementations for the methods in the **`Flow
 
     For example, you can choose to not obfuscate the email but obfuscate the user name by keeping the first two characters and replacing the other characters with several "\_" characters:
 
-    ```Java
-    @NotNull
-    @Override
-    public String obfuscateEmail(@NotNull String email) {
-        return email;
-    }
+   ```Java
+   @NotNull
+   @Override
+   public String obfuscateEmail(@NotNull String email) {
+       return email;
+   }
 
-    @NotNull
-    @Override
-    public String obfuscateUserName(@NotNull String name) {
-        if(name.isEmpty()) {
-            return name;
-        }
-        if (name.length() > 2) {
-            return name.substring(0, 2) + "____";
-        } else {
-            return name.substring(0, 1) + "_____";
-        }
-    }
-    ```
+   @NotNull
+   @Override
+   public String obfuscateUserName(@NotNull String name) {
+       if(name.isEmpty()) {
+           return name;
+       }
+       if (name.length() > 2) {
+           return name.substring(0, 2) + "____";
+       } else {
+           return name.substring(0, 1) + "_____";
+       }
+   }
+   ```
 
 5.  The **`FlowActionHandler`** provides a method for the client code to add "back button press" logic when a web view is displayed for authentication. For some authentication types, the onboarding flow will open a web view for authentication. You can add your own logic to specify what action is taken when the **`Back`** button of the web view is pressed.
 
@@ -367,34 +367,34 @@ This section provides some sample implementations for the methods in the **`Flow
 
     The following sample code implements a warning dialog when the **`Back`** button is pressed:
 
-    ```Java
-    @Nullable
-    @Override
-    public Function0<Unit> getOnWebViewBackPressed() {
-        return () -> {
-            Activity activity = AppLifecycleCallbackHandler.getInstance().getActivity();
-            new AlertDialog.Builder(activity)
-                    .setMessage("Are you sure you want to exit onboarding flow?")
-                    .setPositiveButton("OK",
-                            new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog, int which) {
-                                    dialog.dismiss();
-                                    activity.finish();
-                                }
-                            }
-                    ).setNegativeButton("Cancel",
-                    new DialogInterface.OnClickListener() {
-                        @Override
-                        public void onClick(DialogInterface dialog, int which) {
-                            dialog.dismiss();
-                        }
-                    }
-            ).create().show();
-            return null;
-        };
-    }
-    ```
+   ```Java
+   @Nullable
+   @Override
+   public Function0<Unit> getOnWebViewBackPressed() {
+       return () -> {
+           Activity activity = AppLifecycleCallbackHandler.getInstance().getActivity();
+           new AlertDialog.Builder(activity)
+                   .setMessage("Are you sure you want to exit onboarding flow?")
+                   .setPositiveButton("OK",
+                           new DialogInterface.OnClickListener() {
+                               @Override
+                               public void onClick(DialogInterface dialog, int which) {
+                                   dialog.dismiss();
+                                   activity.finish();
+                               }
+                           }
+                   ).setNegativeButton("Cancel",
+                   new DialogInterface.OnClickListener() {
+                       @Override
+                       public void onClick(DialogInterface dialog, int which) {
+                           dialog.dismiss();
+                       }
+                   }
+           ).create().show();
+           return null;
+       };
+   }
+   ```
 
 [OPTION END]
 
@@ -409,14 +409,14 @@ This section provides some sample implementations for the methods in the **`Flow
 
     The first two methods allow you to add additional rules for passcode policy and the last method is for you to add your own validation logic in additional to the rules defined in the passcode policy. For example, when the passcode policy allows special characters, you can still add the logic to disable certain special characters. For instance, the sample code below prevents the user from being able to use "@" as one of the possible special character:
 
-    ```Kotlin
-    override fun validatePasscode(code: CharArray): Boolean {
-        if(code.contains('@')) {
-            return false
-        }
-        return super.validatePasscode(code)
-    }
-    ```
+   ```Kotlin
+   override fun validatePasscode(code: CharArray): Boolean {
+       if(code.contains('@')) {
+           return false
+       }
+       return super.validatePasscode(code)
+   }
+   ```
 
 2.  The **`FlowActionHandler`** provides two methods related to the QR code:
 
@@ -428,18 +428,18 @@ This section provides some sample implementations for the methods in the **`Flow
 
     For example, you can specify that the QR code must contain some particular properties:
 
-    ```Kotlin
-    override fun validateBarcode(barcode: String): ServiceResult<Boolean> {
-        return if (barcode != null && barcode.contains("AppId") && barcode.contains("ClientId")
-                && barcode.contains("AuthorizationEndpointUrl")
-                && barcode.contains("ServerUrl") && barcode.contains("RedirectUrl")
-                && barcode.contains("TokenUrl")) {
-            ServiceResult.SUCCESS(true)
-        } else {
-            ServiceResult.FAILURE("")
-        }
-    }
-    ```
+   ```Kotlin
+   override fun validateBarcode(barcode: String): ServiceResult<Boolean> {
+       return if (barcode != null && barcode.contains("AppId") && barcode.contains("ClientId")
+               && barcode.contains("AuthorizationEndpointUrl")
+               && barcode.contains("ServerUrl") && barcode.contains("RedirectUrl")
+               && barcode.contains("TokenUrl")) {
+           ServiceResult.SUCCESS(true)
+       } else {
+           ServiceResult.FAILURE("")
+       }
+   }
+   ```
 
 3.  The **`FlowActionHandler`** provides two methods related to the certificate handling:
 
@@ -451,12 +451,12 @@ This section provides some sample implementations for the methods in the **`Flow
 
     For example, you can create a **`SslClientAuth`** instance using a **`ChooseCertificateProvider`** instance to pop up a dialog for user to choose a certificate:
 
-    ```Kotlin
-    override fun onCertificateSslClientAuthPrepared(): SslClientAuth {
-        val chooseCertificateProvider = ChooseCertificateProvider()
-        return SslClientAuth(chooseCertificateProvider)
-    }
-    ```
+   ```Kotlin
+   override fun onCertificateSslClientAuthPrepared(): SslClientAuth {
+       val chooseCertificateProvider = ChooseCertificateProvider()
+       return SslClientAuth(chooseCertificateProvider)
+   }
+   ```
 
 4.  The **`FlowActionHandler`** provides two methods for user name and email obfuscation when displaying the information on sign-in screen:
 
@@ -466,22 +466,22 @@ This section provides some sample implementations for the methods in the **`Flow
 
     For example, you can choose to not obfuscate the email but obfuscate the user name by keeping the first two characters and replacing the other characters with several "\_" characters:
 
-    ```Kotlin
-    override fun obfuscateEmail(email: String): String {
-        return email
-    }
+   ```Kotlin
+   override fun obfuscateEmail(email: String): String {
+       return email
+   }
 
-    override fun obfuscateUserName(name: String): String {
-        if (name.isEmpty()) {
-            return name
-        }
-        return if (name.length > 2) {
-            name.substring(0, 2) + "____"
-        } else {
-            name.substring(0, 1) + "_____"
-        }
-    }
-    ```
+   override fun obfuscateUserName(name: String): String {
+       if (name.isEmpty()) {
+           return name
+       }
+       return if (name.length > 2) {
+           name.substring(0, 2) + "____"
+       } else {
+           name.substring(0, 1) + "_____"
+       }
+   }
+   ```
 
 5.  The **`FlowActionHandler`** provides a method for the client code to add "back button press" logic when a web view is displayed for authentication. For some authentication types, the onboarding flow will open a web view for authentication. You can add your own logic to specify what action is taken when the **`Back`** button of the web view is pressed.
 
@@ -489,21 +489,21 @@ This section provides some sample implementations for the methods in the **`Flow
 
     The following sample code implements a warning dialog when the **`Back`** button is pressed:
 
-    ```Kotlin
-    override val onWebViewBackPressed: () -> Unit = {
-        val activity = AppLifecycleCallbackHandler.getInstance().activity
-        activity?.let {
-            AlertDialog.Builder(activity)
-                .setMessage("Are you sure you want to exit onboarding flow?")
-                .setPositiveButton("OK") { dialog, _ ->
-                    activity.finish()
-                    dialog.dismiss()
-                }.setNegativeButton("Cancel") { dialog, _ ->
-                    dialog.dismiss()
-                }.show()
-        }
-    }
-    ```
+   ```Kotlin
+   override val onWebViewBackPressed: () -> Unit = {
+       val activity = AppLifecycleCallbackHandler.getInstance().activity
+       activity?.let {
+           AlertDialog.Builder(activity)
+               .setMessage("Are you sure you want to exit onboarding flow?")
+               .setPositiveButton("OK") { dialog, _ ->
+                   activity.finish()
+                   dialog.dismiss()
+               }.setNegativeButton("Cancel") { dialog, _ ->
+                   dialog.dismiss()
+               }.show()
+       }
+   }
+   ```
 
 [OPTION END]
 

--- a/tutorials/sdk-android-flows-passcode/sdk-android-flows-passcode.md
+++ b/tutorials/sdk-android-flows-passcode/sdk-android-flows-passcode.md
@@ -82,15 +82,15 @@ primary_tag: products>sap-btp-sdk-for-android
 
 3.  To start a "forgot passcode" flow, set the flow type as **`FlowType.FORGOT_PASSCODE`** and set the user ID who forgot the passcode for the **`FlowContext`** instance, and then call the `start` method of the `Flow` class to start the flow.
 
-    ```Java
-    FlowContext flowContext = new FlowContextBuilder()
-                .setApplication(new AppConfig.Builder().applicationId("app_id").addAuth(
-                        new BasicAuth()).build())
-                .setFlowType(FlowType.FORGOT_PASSCODE)
-                .setForgotPasscodeUserId("TestUser")
-                .build();
-    Flow.start(this, flowContext);
-    ```
+   ```Java
+   FlowContext flowContext = new FlowContextBuilder()
+               .setApplication(new AppConfig.Builder().applicationId("app_id").addAuth(
+                       new BasicAuth()).build())
+               .setFlowType(FlowType.FORGOT_PASSCODE)
+               .setForgotPasscodeUserId("TestUser")
+               .build();
+   Flow.start(this, flowContext);
+   ```
 
 [OPTION END]
 
@@ -110,16 +110,16 @@ primary_tag: products>sap-btp-sdk-for-android
 
 3.  To start a "forgot passcode" flow, set the flow type as **`FlowType.FORGOT_PASSCODE`** and set the user ID who forgot the passcode for the **`FlowContext`** instance, and then call the `start` method of the `Flow` class to start the flow.
 
-    ```Kotlin
-    val flowContext = FlowContextBuilder()
-                .setApplication(AppConfig.Builder().applicationId("app_id")
-                                    .addAuth(BasicAuth())
-                                    .build())
-                .setFlowType(FlowType.FORGOT_PASSCODE)
-                .setForgotPasscodeUserId("TestUser")
-                .build()
-    Flow.start(this, flowContext)
-    ```
+   ```Kotlin
+   val flowContext = FlowContextBuilder()
+               .setApplication(AppConfig.Builder().applicationId("app_id")
+                                   .addAuth(BasicAuth())
+                                   .build())
+               .setFlowType(FlowType.FORGOT_PASSCODE)
+               .setForgotPasscodeUserId("TestUser")
+               .build()
+   Flow.start(this, flowContext)
+   ```
 
 [OPTION END]
 
@@ -134,14 +134,14 @@ primary_tag: products>sap-btp-sdk-for-android
 
 2.  To start a "verify passcode" flow, set the flow type as **`FlowType.VERIFY_PASSCODE`** and then call the `start` method of the `Flow` class to start the flow.
 
-    ```Java
-    FlowContext flowContext = new FlowContextBuilder()
-                .setApplication(new AppConfig.Builder().applicationId("app_id").addAuth(
-                        new BasicAuth()).build())
-                .setFlowType(FlowType.VERIFY_PASSCODE)
-                .build();
-    Flow.start(this, flowContext);
-    ```
+   ```Java
+   FlowContext flowContext = new FlowContextBuilder()
+               .setApplication(new AppConfig.Builder().applicationId("app_id").addAuth(
+                       new BasicAuth()).build())
+               .setFlowType(FlowType.VERIFY_PASSCODE)
+               .build();
+   Flow.start(this, flowContext);
+   ```
 
 3.  When biometric authentication is enabled by the user, the flow will display the "Sign In with Biometric" screen for user to authenticate with biometric information.
 
@@ -159,15 +159,15 @@ primary_tag: products>sap-btp-sdk-for-android
 
 2.  To start a "verify passcode" flow, set the flow type as **`FlowType.VERIFY_PASSCODE`** and then call the `start` method of the `Flow` class to start the flow.
 
-    ```Kotlin
-    val flowContext = FlowContextBuilder()
-                .setApplication(AppConfig.Builder().applicationId("app_id")
-                                    .addAuth(BasicAuth())
-                                    .build())
-                .setFlowType(FlowType.VERIFY_PASSCODE)
-                .build()
-    Flow.start(this, flowContext)
-    ```
+   ```Kotlin
+   val flowContext = FlowContextBuilder()
+               .setApplication(AppConfig.Builder().applicationId("app_id")
+                                   .addAuth(BasicAuth())
+                                   .build())
+               .setFlowType(FlowType.VERIFY_PASSCODE)
+               .build()
+   Flow.start(this, flowContext)
+   ```
 
 3.  When biometric authentication is enabled by the user, the flow will display the "Sign In with Biometric" screen for user to authenticate with biometric information.
 

--- a/tutorials/sdk-android-flows-restore/sdk-android-flows-restore.md
+++ b/tutorials/sdk-android-flows-restore/sdk-android-flows-restore.md
@@ -88,16 +88,16 @@ There may be occasions when the user wants to reset the app to initial state. Th
 
     You can customize your client code so that the reset flow hides this dialog by setting the value of **`needConfirmWhenReset`** parameter to **`false`** for the **`FlowOptions`** instance and set this **`FlowOptions`** instance for the **`FlowContext`** instance to start the reset flow.
 
-    ```Kotlin
-    val flowContext =
-            FlowContextBuilder()
-                    .setFlowType(FlowType.RESET)
-                    .setFlowOptions(FlowOptions(
-                            needConfirmWhenReset = false
-                    ))
-                    .build()
-    Flow.start(this, flowContext)
-    ```
+   ```Kotlin
+   val flowContext =
+           FlowContextBuilder()
+                   .setFlowType(FlowType.RESET)
+                   .setFlowOptions(FlowOptions(
+                           needConfirmWhenReset = false
+                   ))
+                   .build()
+   Flow.start(this, flowContext)
+   ```
 
 5.  Before removing all the data managed by the Flows component, the reset flow will notify the `ApplicationReset` event. You can use the `onApplicationReset` callback of the `FlowStateListener` instance to insert its own logic for application reset, for example to clear the data managed by the client code and un-register the push token.
 
@@ -123,17 +123,17 @@ There may be occasions when the user wants to reset the app to initial state. Th
 
     You can customize your client code so that the reset flow hides this dialog by overriding the **`isResetConfirmationNeeded`** function of the **`FlowOptions`** instance to return **`false`** and set this **`FlowOptions`** instance for the **`FlowContext`** instance to start the reset flow.
 
-    ```Java
-    FlowContext flowContext = new FlowContextBuilder()
-                .setFlowType(FlowType.RESET)
-                .setFlowOptions(new FlowOptions(){
-                    @Override
-                    public boolean isResetConfirmationNeeded() {
-                        return false;
-                    }
-                }).build();
-    Flow.start(this, flowContext);
-    ```
+   ```Java
+   FlowContext flowContext = new FlowContextBuilder()
+               .setFlowType(FlowType.RESET)
+               .setFlowOptions(new FlowOptions(){
+                   @Override
+                   public boolean isResetConfirmationNeeded() {
+                       return false;
+                   }
+               }).build();
+   Flow.start(this, flowContext);
+   ```
 
 5.  Before removing all the data managed by the Flows component, the reset flow will notify the `ApplicationReset` event. You can use the `onApplicationReset` callback of the `FlowStateListener` instance to insert its own logic for application reset, for example to clear the data managed by the client code and un-register the push token.
 
@@ -164,43 +164,43 @@ The logout flow will try to logout the current user if network is available, the
 
     You can customize your client code so that the logout flow hides this dialog by setting the value of **`needConfirmWhenLogout`** parameter to **`false`** for the **`FlowOptions`** instance and set this **`FlowOptions`** instance for the **`FlowContext`** instance to start the reset flow.
 
-    ```Kotlin
-    val flowContext =
-            FlowContextBuilder()
-                    .setFlowType(FlowType.LOGOUT)
-                    .setFlowOptions(FlowOptions(
-                            needConfirmWhenLogout = false
-                    ))
-                    .build()
-    Flow.start(this, flowContext)
-    ```
+   ```Kotlin
+   val flowContext =
+           FlowContextBuilder()
+                   .setFlowType(FlowType.LOGOUT)
+                   .setFlowOptions(FlowOptions(
+                           needConfirmWhenLogout = false
+                   ))
+                   .build()
+   Flow.start(this, flowContext)
+   ```
 
 5.  Logout flow will not automatically remove the push registration. Client code can implement the callback function **`FlowActivityResultCallback`** to delete the Firebase push token if it does not want to receive push notifications after logout. The logout flow will trigger the callback function after a successful logout.
 
-    ```Kotlin
-    Flow.start(
-        this,
-        FlowContextRegistry.flowContext.    
-        copy(
-            flowType = FlowType.LOGOUT)){
-            _, resultCode, _->
-            if(resultCode ==RESULT_OK) {
-                SDKInitializer.getService
-                (FirebasePushService::class)?.also
-                {
-                    FirebaseMessaging.getInstance().
-                    deleteToken().addOnSuccessListener
-                    { 
-                        Log.e("PushService","PushService token was revoked!") 
-                    }
-                    .addOnFailureListener { e1: Exception? ->
+   ```Kotlin
+   Flow.start(
+       this,
+       FlowContextRegistry.flowContext.    
+       copy(
+           flowType = FlowType.LOGOUT)){
+           _, resultCode, _->
+           if(resultCode ==RESULT_OK) {
+               SDKInitializer.getService
+               (FirebasePushService::class)?.also
+               {
+                   FirebaseMessaging.getInstance().
+                   deleteToken().addOnSuccessListener
+                   { 
+                       Log.e("PushService","PushService token was revoked!") 
+                   }
+                   .addOnFailureListener { e1: Exception? ->
 
-                        Log.e("PushService","PushService token couldn't be revoked!:$e1")
-                    }
-                }
-            }
-        }
-    ```
+                       Log.e("PushService","PushService token couldn't be revoked!:$e1")
+                   }
+               }
+           }
+       }
+   ```
 
 Congratulations! You now have learned how to restore, reset and logout an application using the Flows component!
 

--- a/tutorials/sdk-android-flows-theme/sdk-android-flows-theme.md
+++ b/tutorials/sdk-android-flows-theme/sdk-android-flows-theme.md
@@ -43,114 +43,114 @@ An enterprise mobile application usually has its own branding theme, and therefo
 
 1.  Define your logo. To change the logo image at the top of each onboarding screen , define the following style in the `styles.xml` file.
 
-    ```XML
-    <style name="OnboardingLogo">
-        <!-- The value is always @drawable/<your_logo_name_without_ext> -->
-        <!-- Do not add the file extension e.g. .png -->
-        <item name="android:src">@drawable/custom_logo</item>
-        <item name="android:layout_height">72dp</item>
-        <item name="android:layout_width">72dp</item>
-    </style>
-    ```
+   ```XML
+   <style name="OnboardingLogo">
+       <!-- The value is always @drawable/<your_logo_name_without_ext> -->
+       <!-- Do not add the file extension e.g. .png -->
+       <item name="android:src">@drawable/custom_logo</item>
+       <item name="android:layout_height">72dp</item>
+       <item name="android:layout_width">72dp</item>
+   </style>
+   ```
 2.  Define styles for flat and raised button. Both raised and flat button styles can be customized by specifying **`onboarding_button_flat_ref`** and **`onboarding_button_raised_ref`**. And the client code can also define the button background color and text color for different states.
 
-    ```XML
-    <!-- onboarding flat button -->
-    <item name="onboarding_button_flat_ref">@style/Widget.Onboarding.Button.Borderless</item>
-    <item name="onboarding_button_flat_text">@color/sap_ui_flat_button_text_color</item>
-    <item name="onboarding_button_flat_text_disabled">
-        @color/onboarding_button_flat_text_disabled
-    </item>
-    <item name="onboarding_button_flat_background">
-        @color/onboarding_button_flat_background
-    </item>
+   ```XML
+   <!-- onboarding flat button -->
+   <item name="onboarding_button_flat_ref">@style/Widget.Onboarding.Button.Borderless</item>
+   <item name="onboarding_button_flat_text">@color/sap_ui_flat_button_text_color</item>
+   <item name="onboarding_button_flat_text_disabled">
+       @color/onboarding_button_flat_text_disabled
+   </item>
+   <item name="onboarding_button_flat_background">
+       @color/onboarding_button_flat_background
+   </item>
 
-    <!-- onboarding raised button -->
-    <item name="onboarding_button_raised_ref">@style/Widget.Onboarding.Button.Borderless</item>
-    <item name="onboarding_button_raised_background_pressed">@color/onboarding_button_raised_background_pressed</item>
-    <item name="onboarding_button_raised_background_disabled">@color/onboarding_button_raised_background_disabled</item>
-    <item name="onboarding_button_raised_background">@color/onboarding_button_raised_background</item>
-    ```
+   <!-- onboarding raised button -->
+   <item name="onboarding_button_raised_ref">@style/Widget.Onboarding.Button.Borderless</item>
+   <item name="onboarding_button_raised_background_pressed">@color/onboarding_button_raised_background_pressed</item>
+   <item name="onboarding_button_raised_background_disabled">@color/onboarding_button_raised_background_disabled</item>
+   <item name="onboarding_button_raised_background">@color/onboarding_button_raised_background</item>
+   ```
 
 3.  Define styles for text input fields. The onboarding screens use the Fiori UI component **`SimplePropertyFormCell`** for the text input fields. Client code can customize the style and text color for the component.
 
-    ```XML
-    <!-- SimplePropertyFormCell -->
-    <item name="onboarding_simple_property_focused_ref">
-        @style/Onboarding.SimplePropertyFormCell.Focused
-    </item>
-    <item name="onboarding_simple_property_focused_text_color">@color/onboarding_formcell_text</item>
-    <item name="onboarding_simple_property_unfocused_ref">
-        @style/Onboarding.SimplePropertyFormCell.Unfocused
-    </item>
-    <item name="onboarding_simple_property_unfocused_text_color">@color/onboarding_base_text</item>
-    ```
+   ```XML
+   <!-- SimplePropertyFormCell -->
+   <item name="onboarding_simple_property_focused_ref">
+       @style/Onboarding.SimplePropertyFormCell.Focused
+   </item>
+   <item name="onboarding_simple_property_focused_text_color">@color/onboarding_formcell_text</item>
+   <item name="onboarding_simple_property_unfocused_ref">
+       @style/Onboarding.SimplePropertyFormCell.Unfocused
+   </item>
+   <item name="onboarding_simple_property_unfocused_text_color">@color/onboarding_base_text</item>
+   ```
 
-    Besides the above theme attributes, client code can customize the active border for **`SimplePropertyFormCell`** in the `colors.xml` file.
+   Besides the above theme attributes, client code can customize the active border for **`SimplePropertyFormCell`** in the `colors.xml` file.
 
-    ```XML
-    <!-- SimplePropertyFormCell active value border -->
-    <color name="sap_ui_field_active_border_color">@color/onboarding_active_border</color>
-    ```
+   ```XML
+   <!-- SimplePropertyFormCell active value border -->
+   <color name="sap_ui_field_active_border_color">@color/onboarding_active_border</color>
+   ```
 
 4.  Define the theme. Put all the customized styles in a theme extended from the parent theme **`FioriTheme.Onboarding`**, so the client code can only provide the customized styles and simply use the default style in **`FioriTheme.Onboarding`** for the others.
 
-    ```XML
-    <!-- styles.xml -->
-    <style name="AppTheme" parent="FioriTheme.Onboarding">
+   ```XML
+   <!-- styles.xml -->
+   <style name="AppTheme" parent="FioriTheme.Onboarding">
 
-        <!-- Customize your theme here. -->
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
+       <!-- Customize your theme here. -->
+       <item name="colorPrimary">@color/colorPrimary</item>
+       <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+       <item name="colorAccent">@color/colorAccent</item>
 
-        <!-- Sign In screen avatar background -->
-        <item name="onboarding_avatar_background">@color/colorPrimary</item>
-        <!-- If commented out, the default value in the 'onboarding' theme will be used.
-        <item name="onboarding_avatar_text_color">@color/onboarding_avatar_text_color</item>
-        -->
+       <!-- Sign In screen avatar background -->
+       <item name="onboarding_avatar_background">@color/colorPrimary</item>
+       <!-- If commented out, the default value in the 'onboarding' theme will be used.
+       <item name="onboarding_avatar_text_color">@color/onboarding_avatar_text_color</item>
+       -->
 
-        <!-- onboarding raised button -->
-        <item name="onboarding_button_raised_background_pressed">@color/colorPrimary</item>
-        <item name="onboarding_button_raised_background_disabled">@color/colorPrimaryDark</item>
-        <item name="onboarding_button_raised_background">@color/colorPrimary</item>
+       <!-- onboarding raised button -->
+       <item name="onboarding_button_raised_background_pressed">@color/colorPrimary</item>
+       <item name="onboarding_button_raised_background_disabled">@color/colorPrimaryDark</item>
+       <item name="onboarding_button_raised_background">@color/colorPrimary</item>
 
-        <!-- onboarding flat button -->
-        <item name="onboarding_button_flat_text">@color/colorAccent</item>
-        <item name="onboarding_button_flat_text_disabled">@color/colorPrimaryDark</item>
-        <item name="onboarding_button_flat_background">@color/onboarding_default_background</item>
+       <!-- onboarding flat button -->
+       <item name="onboarding_button_flat_text">@color/colorAccent</item>
+       <item name="onboarding_button_flat_text_disabled">@color/colorPrimaryDark</item>
+       <item name="onboarding_button_flat_background">@color/onboarding_default_background</item>
 
-        <!-- SimplePropertyFormCell -->
-        <item name="onboarding_simple_property_focused_text_color">@color/colorAccent</item>
-        <item name="onboarding_simple_property_unfocused_text_color">@color/colorPrimaryDark</item>
-    </style>
+       <!-- SimplePropertyFormCell -->
+       <item name="onboarding_simple_property_focused_text_color">@color/colorAccent</item>
+       <item name="onboarding_simple_property_unfocused_text_color">@color/colorPrimaryDark</item>
+   </style>
 
-    <style name="OnboardingLogo">
-        <!-- The value is always @drawable/<your_logo_name_without_ext> -->
-        <!-- Do not add the file extension e.g. .png -->
-        <item name="android:src">@drawable/custom_logo</item>
-        <item name="android:layout_height">72dp</item>
-        <item name="android:layout_width">72dp</item>
-    </style>
-    ```
+   <style name="OnboardingLogo">
+       <!-- The value is always @drawable/<your_logo_name_without_ext> -->
+       <!-- Do not add the file extension e.g. .png -->
+       <item name="android:src">@drawable/custom_logo</item>
+       <item name="android:layout_height">72dp</item>
+       <item name="android:layout_width">72dp</item>
+   </style>
+   ```
 
-    Define the colors in `colors.xml` file.
+   Define the colors in `colors.xml` file.
 
-    ```XML
-    <!-- colors.xml -->
-    <!-- Primary colors -->
-    <color name="colorPrimary">@color/colorPrimaryRed</color>
-    <color name="colorPrimaryDark">@color/colorPrimaryDarkRed</color>
-    <color name="colorAccent">@color/colorAccentRed</color>
+   ```XML
+   <!-- colors.xml -->
+   <!-- Primary colors -->
+   <color name="colorPrimary">@color/colorPrimaryRed</color>
+   <color name="colorPrimaryDark">@color/colorPrimaryDarkRed</color>
+   <color name="colorAccent">@color/colorAccentRed</color>
 
-    <!-- Red Theme -->
-    <color name="colorPrimaryRed">#d12920</color>
-    <color name="colorPrimaryDarkRed">#631216</color>
-    <color name="colorAccentRed">#ab1d22</color>
+   <!-- Red Theme -->
+   <color name="colorPrimaryRed">#d12920</color>
+   <color name="colorPrimaryDarkRed">#631216</color>
+   <color name="colorAccentRed">#ab1d22</color>
 
-    <!-- SimplePropertyFormCell active value border -->
-    <color name="sap_ui_field_active_border_color">@color/colorPrimaryDark</color>
-    ```
+   <!-- SimplePropertyFormCell active value border -->
+   <color name="sap_ui_field_active_border_color">@color/colorPrimaryDark</color>
+   ```
 
 [DONE]
 [ACCORDION-END]
@@ -161,22 +161,22 @@ An enterprise mobile application usually has its own branding theme, and therefo
 
 1.  To notify the customized theme to the Flows component, create a **`FlowOptions`** instance that overrides the **`getApplicationTheme`** function to return the theme ID and set this **`FlowOptions`** instance for the **`FlowContext`** instance to start the flow.
 
-    ```Java
-    FlowContext flowContext = new FlowContextBuilder()
-                .setApplication(appConfig)
-                .setFlowOptions(new FlowOptions(){
-                    @Override
-                    public boolean getApplicationTheme() {
-                        return R.style.AppTheme;
-                    }
-                }).build();
-    Flow.Companion.start(context, flowContext, (code, result, data) -> {
-        if(result == RESULT_OK) {
-            startMainBusinessActivity();
-        }
-        return null;
-    });
-    ```
+   ```Java
+   FlowContext flowContext = new FlowContextBuilder()
+               .setApplication(appConfig)
+               .setFlowOptions(new FlowOptions(){
+                   @Override
+                   public boolean getApplicationTheme() {
+                       return R.style.AppTheme;
+                   }
+               }).build();
+   Flow.Companion.start(context, flowContext, (code, result, data) -> {
+       if(result == RESULT_OK) {
+           startMainBusinessActivity();
+       }
+       return null;
+   });
+   ```
 
 2.  After applying the customized theme and style, the look and feel of the wizard-generated app are changed accordingly.
 
@@ -188,19 +188,19 @@ An enterprise mobile application usually has its own branding theme, and therefo
 
 1.  To notify the customized theme to the Flows component, set the theme ID as the value of **`appTheme`** parameter for the **`FlowOptions`** instance and set this **`FlowOptions`** instance for the **`FlowContext`** instance to start the flow.
 
-    ```Kotlin
-    val flowContext = FlowContext(
-        appConfig = AppConfig.Builder().applicationId("app_id").build(),
-        flowOptions = FlowOptions(
-            appTheme = R.style.AppTheme
-        )
-    )
-    Flow.start(this@WelcomeActivity, flowContext) { requestCode, resultCode, _ ->
-        if (resultCode == Activity.RESULT_OK) {
-            startMainBusinessActivity()
-        }
-    }
-    ```
+   ```Kotlin
+   val flowContext = FlowContext(
+       appConfig = AppConfig.Builder().applicationId("app_id").build(),
+       flowOptions = FlowOptions(
+           appTheme = R.style.AppTheme
+       )
+   )
+   Flow.start(this@WelcomeActivity, flowContext) { requestCode, resultCode, _ ->
+       if (resultCode == Activity.RESULT_OK) {
+           startMainBusinessActivity()
+       }
+   }
+   ```
 
 2.  After applying the customized theme and style, the look and feel of the wizard-generated app are changed accordingly.
 
@@ -219,33 +219,33 @@ Client code may use its own screens in onboarding process or implement customize
 
 1.  To customize an activity, client code must define the theme in the AndroidManifest.xml file.
 
-    ```XML
-    <!-- AndroidManifest.xml -->
-    <activity
-        android:name=".WelcomeActivity"
-        android:theme="@style/AppTheme.NoActionBar">
-        <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
-            <category android:name="android.intent.category.LAUNCHER" />
-        </intent-filter>
-    </activity>
+   ```XML
+   <!-- AndroidManifest.xml -->
+   <activity
+       android:name=".WelcomeActivity"
+       android:theme="@style/AppTheme.NoActionBar">
+       <intent-filter>
+           <action android:name="android.intent.action.MAIN" />
+           <category android:name="android.intent.category.LAUNCHER" />
+       </intent-filter>
+   </activity>
 
-    <!-- styles.xml -->
-    <style name="AppTheme.NoActionBar" parent="AppTheme">
-    ...
-    </style>
-    ```
+   <!-- styles.xml -->
+   <style name="AppTheme.NoActionBar" parent="AppTheme">
+   ...
+   </style>
+   ```
 
 2.  To customize a fragment, such as a `FlowStepFragment` for a customized flow, use the following code in the `onCreateView` method of the fragment.
 
-    ```Java
-    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
-            @Nullable Bundle savedInstanceState) {
-        ContextThemeWrapper themeWrapper = new ContextThemeWrapper(getActivity(), R.style.AppTheme);
-        CustomStepFragmentBinding binding = CustomStepFragmentBinding.inflate(inflater.cloneInContext(themeWrapper), container, false);
-        return binding.getRoot();
-    }
-    ```
+   ```Java
+   public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+           @Nullable Bundle savedInstanceState) {
+       ContextThemeWrapper themeWrapper = new ContextThemeWrapper(getActivity(), R.style.AppTheme);
+       CustomStepFragmentBinding binding = CustomStepFragmentBinding.inflate(inflater.cloneInContext(themeWrapper), container, false);
+       return binding.getRoot();
+   }
+   ```
 
 [OPTION END]
 
@@ -253,38 +253,38 @@ Client code may use its own screens in onboarding process or implement customize
 
 1.  To customize an activity, client code must define the theme in the AndroidManifest.xml file.
 
-    ```XML
-    <!-- AndroidManifest.xml -->
-    <activity
-        android:name=".WelcomeActivity"
-        android:theme="@style/AppTheme.NoActionBar">
-        <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
-            <category android:name="android.intent.category.LAUNCHER" />
-        </intent-filter>
-    </activity>
+   ```XML
+   <!-- AndroidManifest.xml -->
+   <activity
+       android:name=".WelcomeActivity"
+       android:theme="@style/AppTheme.NoActionBar">
+       <intent-filter>
+           <action android:name="android.intent.action.MAIN" />
+           <category android:name="android.intent.category.LAUNCHER" />
+       </intent-filter>
+   </activity>
 
-    <!-- styles.xml -->
-    <style name="AppTheme.NoActionBar" parent="AppTheme">
-    ...
-    </style>
-    ```
+   <!-- styles.xml -->
+   <style name="AppTheme.NoActionBar" parent="AppTheme">
+   ...
+   </style>
+   ```
 
 2.  To customize a fragment, such as a `FlowStepFragment` for a customized flow, use the following code in the `onCreateView` method of the fragment.
 
-    ```Kotlin
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        val themeWrapper = ContextThemeWrapper(
-                activity,
-                R.style.AppTheme
-            )
-        val binding = CustomStepFragmentBinding.inflate(layoutInflater.cloneInContext(themeWrapper), container, false)
-        return binding.root
-    }
-    ```
+   ```Kotlin
+   override fun onCreateView(
+       inflater: LayoutInflater, container: ViewGroup?,
+       savedInstanceState: Bundle?
+   ): View {
+       val themeWrapper = ContextThemeWrapper(
+               activity,
+               R.style.AppTheme
+           )
+       val binding = CustomStepFragmentBinding.inflate(layoutInflater.cloneInContext(themeWrapper), container, false)
+       return binding.root
+   }
+   ```
 
 [OPTION END]
 

--- a/tutorials/sdk-android-flowsjc-onboarding/sdk-android-flowsjc-onboarding.md
+++ b/tutorials/sdk-android-flowsjc-onboarding/sdk-android-flowsjc-onboarding.md
@@ -38,31 +38,31 @@ The visibility and the content of each screen will vary depending on the differe
 
 1.  By default, the first screen of the onboarding flow is the EULA screen. This screen allows users to review and agree to the end user license agreement. To exclude this screen, set the value of **`useDefaultEulaScreen`** parameter to **`false`** for the **`FlowOptions`** instance and set this **`FlowOptions`** instance for the **`FlowContext`** instance to start the onboarding flow.
 
-    ```Kotlin
-    val flowContext = FlowContext(
-        appConfig = appConfig,
-        flowOptions = FlowOptions(
-            useDefaultEulaScreen = false
-    )
-    FlowUtil.startFlow(activity, flowContext)
-    ```
+   ```Kotlin
+   val flowContext = FlowContext(
+       appConfig = appConfig,
+       flowOptions = FlowOptions(
+           useDefaultEulaScreen = false
+   )
+   FlowUtil.startFlow(activity, flowContext)
+   ```
 
-    Notice that if the EULA screen is excluded, it will be the responsibility of the client code to handle the end user license agreement.
+   Notice that if the EULA screen is excluded, it will be the responsibility of the client code to handle the end user license agreement.
 
 2.  If the **`AppConfig`** instance in **`FlowContext`** does not provide the authentication info or host for the mobile application, the activation screen will be displayed to get the complete **`AppConfig`** from either the `Discovery Service`, `QR code scanning` or `MDM`. By default, the QR code scanning screen will be displayed. The client code can customize the screen to display other activation screens.
 
     Create a **`FlowOptions`** instance and set the value for **`activationOption`** parameter, **`ActivationOption.DS_ONLY`** value to display the `Discovery Service` method only, **`ActivationOption.MDM_ONLY`** value to display the `MDM` method only and **`ActivationOption.DS_OR_QR`** value to display the activation screen for selecting from both methods. Using the code snippet below, the activation screen will only display the option for Discovery Service.
 
-    ```Kotlin
-    val flowContext = FlowContext(
-        appConfig = appConfig,
-        flowOptions = FlowOptions(
-            activationOption = ActivationOption.DS_ONLY
-    )
-    FlowUtil.startFlow(activity, flowContext)
-    ```
+   ```Kotlin
+   val flowContext = FlowContext(
+       appConfig = appConfig,
+       flowOptions = FlowOptions(
+           activationOption = ActivationOption.DS_ONLY
+   )
+   FlowUtil.startFlow(activity, flowContext)
+   ```
 
-    Notice that if the **`AppConfig`** instance contains complete information, the onboarding flow will skip the activation screen and go directly to the authentication step.
+   Notice that if the **`AppConfig`** instance contains complete information, the onboarding flow will skip the activation screen and go directly to the authentication step.
 
 
 3.  After getting the complete application configuration, the onboarding flow will display different authentication screens based on the authentication type defined for the application. For example, a screen with user input for `User Name` and `Password` properties will be displayed if the authentication type is `Basic`. If the authentication type is `SAML`, the screen will redirect to a web page for user login. The logic to decide which authentication screen to display is built into the onboarding flow and the client code cannot change it.
@@ -71,32 +71,32 @@ The visibility and the content of each screen will vary depending on the differe
 
     Also, the usage consent screen will be skipped if usage reporting is not enabled and the crash report screen will be skipped if crash reporting is not enabled. Otherwise, the screens will be displayed in the  onboarding flow, and the client code cannot alter this fact. To enable the usage reporting and crash reporting services, the client code needs start them using the **`SDKInitializer`** class.
 
-    ```Kotlin
-    val services = mutableListOf<MobileService>()
-    services.add(UsageService())
-    services.add(CrashService())
+   ```Kotlin
+   val services = mutableListOf<MobileService>()
+   services.add(UsageService())
+   services.add(CrashService())
 
-    SDKInitializer.start(this, * services.toTypedArray())
-    ```
+   SDKInitializer.start(this, * services.toTypedArray())
+   ```
 
 5.  Besides the options to include or exclude a step, you can set the client code to customize screens using its  **`ScreenSettings`**, including the title, description, and button text for all screens. For some specific screens, such as the EULA screen, the client code can specify its own URL for the EULA file. See [Onboarding Compose Screens](https://help.sap.com/doc/f53c64b93e5140918d676b927a3cd65b/Cloud/en-US/docs-en/guides/features/onboarding/android/fiori-compose-screens/Overview.html) in the help documentation for information on the detailed settings for each screen in the onboarding process.
 
     To have the customized screen settings take effect in the onboarding flow, set the list of **`ScreenSettings`** for the **`FlowContext`** instance.
 
-    ```Kotlin
-    val customScreenSettings = CustomScreenSettings(
-        eulaSettings = EulaScreenSettings(
-            eulaUrl = "file:///android_asset/my_eula.html"),
-        setPasscodeScreenSettings = SetPasscodeScreenSettings(
-            description = R.string.set_passcode_screen_desc)
-    )
-    val flowContext = FlowContext(
-        appConfig = appConfig,
-        flowOptions = FlowOptions(
-            screenSettings =  customScreenSettings
-    )
-    FlowUtil.startFlow(activity, flowContext)
-    ```
+   ```Kotlin
+   val customScreenSettings = CustomScreenSettings(
+       eulaSettings = EulaScreenSettings(
+           eulaUrl = "file:///android_asset/my_eula.html"),
+       setPasscodeScreenSettings = SetPasscodeScreenSettings(
+           description = R.string.set_passcode_screen_desc)
+   )
+   val flowContext = FlowContext(
+       appConfig = appConfig,
+       flowOptions = FlowOptions(
+           screenSettings =  customScreenSettings
+   )
+   FlowUtil.startFlow(activity, flowContext)
+   ```
 
 [ACCORDION-END]
 
@@ -112,98 +112,98 @@ In this section, we explain the onboarding-related callbacks in **`FlowStateList
 
     !![App Ready](app-ready-kotlin.png)
 
-    ```Kotlin
-    override suspend fun onAppConfigRetrieved(appConfig: AppConfig) {
-        logger.debug("onAppConfigRetrieved: {}", appConfig)
-        SAPServiceManager.initSAPServiceManager(appConfig)
-    }
-    ```
+   ```Kotlin
+   override suspend fun onAppConfigRetrieved(appConfig: AppConfig) {
+       logger.debug("onAppConfigRetrieved: {}", appConfig)
+       SAPServiceManager.initSAPServiceManager(appConfig)
+   }
+   ```
 
 4.  On Windows, press **`Ctrl+F12`**, or, on a Mac, press **`command+F12`**, and type **`onApplicationReset`** to move to the `onApplicationReset` method. The event is notified when reset the application by starting the `reset` flow.
 
     !![App Ready](app-reset-kotlin.png)
 
-    ```Kotlin
-    override suspend fun onApplicationReset() {
-        this.application.resetApplication()
-    }
-    ```
+   ```Kotlin
+   override suspend fun onApplicationReset() {
+       this.application.resetApplication()
+   }
+   ```
 
 5.  On Windows, press **`Ctrl+F12`**, or, on a Mac, press **`command+F12`**, and type **`onClientPolicyRetrieved`** to move to the `onClientPolicyRetrieved` method. After authentication is completed, the onboarding flow will get the client policies from the mobile server and then notify this event. The client code can then create the UI to display the settings.
 
     !![Policy Ready](policy-ready-kotlin.png)
 
-    ```Kotlin
-    override suspend fun onClientPolicyRetrieved(policies: ClientPolicies) {
-        policies.logPolicy?.also { logSettings ->
-            val preferenceRepository = SharedPreferenceRepository(application)
-            val currentSettings =
-                preferenceRepository.userPreferencesFlow.first().logSetting
+   ```Kotlin
+   override suspend fun onClientPolicyRetrieved(policies: ClientPolicies) {
+       policies.logPolicy?.also { logSettings ->
+           val preferenceRepository = SharedPreferenceRepository(application)
+           val currentSettings =
+               preferenceRepository.userPreferencesFlow.first().logSetting
 
-            if (currentSettings.logLevel != logSettings.logLevel) {
-                preferenceRepository.updateLogLevel(LogPolicy.getLogLevel(logSettings))
+           if (currentSettings.logLevel != logSettings.logLevel) {
+               preferenceRepository.updateLogLevel(LogPolicy.getLogLevel(logSettings))
 
-                val logString = when (LogPolicy.getLogLevel(logSettings)) {
-                    Level.ALL -> application.getString(R.string.log_level_path)
-                    Level.INFO -> application.getString(R.string.log_level_info)
-                    Level.WARN -> application.getString(R.string.log_level_warning)
-                    Level.ERROR -> application.getString(R.string.log_level_error)
-                    Level.OFF -> application.getString(R.string.log_level_none)
-                    else -> application.getString(R.string.log_level_debug)
-                }
+               val logString = when (LogPolicy.getLogLevel(logSettings)) {
+                   Level.ALL -> application.getString(R.string.log_level_path)
+                   Level.INFO -> application.getString(R.string.log_level_info)
+                   Level.WARN -> application.getString(R.string.log_level_warning)
+                   Level.ERROR -> application.getString(R.string.log_level_error)
+                   Level.OFF -> application.getString(R.string.log_level_none)
+                   else -> application.getString(R.string.log_level_debug)
+               }
 
-                logger.info(
-                    String.format(
-                        application.getString(R.string.log_level_changed),
-                        logString
-                    )
-                )
+               logger.info(
+                   String.format(
+                       application.getString(R.string.log_level_changed),
+                       logString
+                   )
+               )
 
-                MainScope().launch {
-                    Toast.makeText(
-                        application,
-                        String.format(
-                            application.getString(R.string.log_level_changed),
-                            logString
-                        ),
-                        Toast.LENGTH_SHORT
-                    ).show()
-                }
-            }
-        }
-    }
-    ```
+               MainScope().launch {
+                   Toast.makeText(
+                       application,
+                       String.format(
+                           application.getString(R.string.log_level_changed),
+                           logString
+                       ),
+                       Toast.LENGTH_SHORT
+                   ).show()
+               }
+           }
+       }
+   }
+   ```
 
 6.  On Windows, press **`Ctrl+F12`**, or, on a Mac, press **`command+F12`**, and type **`onFlowFinishedWithData`** to move to the `onFlowFinishedWithData` method. The flows framework will send this event to the client code when a flow finishes successfully and the flow activity is removed from the back stack. Notice that this callback will only be invoked when the flow is successfully completed. If at any time the flow is canceled, this callback will not be invoked.
 
     !![Flow Finish](flow-finish-kotlin.png)
 
-    ```Kotlin
-    override suspend fun onFlowFinishedWithData(flowName: String?, data: Intent?) {
-        when (flowName) {
-            FlowType.Reset.name, FlowType.Logout.name -> launchWelcomeActivity(application)
-            FlowType.DeleteRegistration.name -> {
-                launchWelcomeActivity(application)
-            }
-        }
-    }
-    ```
+   ```Kotlin
+   override suspend fun onFlowFinishedWithData(flowName: String?, data: Intent?) {
+       when (flowName) {
+           FlowType.Reset.name, FlowType.Logout.name -> launchWelcomeActivity(application)
+           FlowType.DeleteRegistration.name -> {
+               launchWelcomeActivity(application)
+           }
+       }
+   }
+   ```
 
 7.  Besides the callbacks implemented in the **`WizardFlowStateListener`** class, the **`OkHttpClientReady`** method is also useful if you want to add an HTTP header into the **`onOkHttpClient`** instance. Before authentication, the **`OkHttpClient`** instance will be ready and sent to the client code using `onOkHttpClientReady`. To add your own HTTP header, override the **`OkHttpClientReady`** method in your flow state listener.
 
-    ```Kotlin
-    override fun onOkHttpClientReady(httpClient: OkHttpClient) {
-        httpClient.addUniqueInterceptor( object: Interceptor {
-            override fun intercept(chain: Interceptor.Chain): Response {
-                val request: Request = chain.request()
-                val newRequest = request.newBuilder()
-                    .header("my_header", "my_header_value")
-                    .build()
-                return chain.proceed(newRequest)
-            }
-        })
-    }
-    ```
+   ```Kotlin
+   override fun onOkHttpClientReady(httpClient: OkHttpClient) {
+       httpClient.addUniqueInterceptor( object: Interceptor {
+           override fun intercept(chain: Interceptor.Chain): Response {
+               val request: Request = chain.request()
+               val newRequest = request.newBuilder()
+                   .header("my_header", "my_header_value")
+                   .build()
+               return chain.proceed(newRequest)
+           }
+       })
+   }
+   ```
 
 >Please see [Flows Extension Point](https://help.sap.com/doc/f53c64b93e5140918d676b927a3cd65b/Cloud/en-US/docs-en/guides/features/onboarding/android/newflows/ExtensionPoints.html) and [`FlowStateListener` in the Flows Component of SAP BTP SDK for Android](https://blogs.sap.com/2021/03/09/flowstatelistener-in-the-flows-component-of-sap-btp-sdk-for-android/) for detailed information on all of the flow states and callbacks. `FlowStateListener` has the same purpose as that in the view-based flows component and the sequence of the callback functions is also the same. The difference is that every callback function is marked as suspend, so it's easier for the client code to call other suspend functions.
 
@@ -227,14 +227,14 @@ This section provides some sample implementations for the methods in the **`Flow
 
     The first two methods allow you to add additional rules for passcode policy and the last method is for you to add your own validation logic in addition to the rules defined in the passcode policy. For example, when the passcode policy allows special characters, you can still add the logic to disable certain special characters. For instance, the sample code below prevents the user from being able to use "@" as one of the possible special characters:
 
-    ```Kotlin
-    override fun validatePasscode(code: CharArray): Boolean {
-        if(code.contains('@')) {
-            return false
-        }
-        return super.validatePasscode(code)
-    }
-    ```
+   ```Kotlin
+   override fun validatePasscode(code: CharArray): Boolean {
+       if(code.contains('@')) {
+           return false
+       }
+       return super.validatePasscode(code)
+   }
+   ```
 
 2.  The **`FlowActionHandler`** provides two methods related to the QR code:
 
@@ -246,18 +246,18 @@ This section provides some sample implementations for the methods in the **`Flow
 
     For example, you can specify that the QR code must contain some particular properties:
 
-    ```Kotlin
-    override fun validateBarcode(barcode: String): ServiceResult<Boolean> {
-        return if (barcode != null && barcode.contains("AppId") && barcode.contains("ClientId")
-                && barcode.contains("AuthorizationEndpointUrl")
-                && barcode.contains("ServerUrl") && barcode.contains("RedirectUrl")
-                && barcode.contains("TokenUrl")) {
-            ServiceResult.SUCCESS(true)
-        } else {
-            ServiceResult.FAILURE("")
-        }
-    }
-    ```
+   ```Kotlin
+   override fun validateBarcode(barcode: String): ServiceResult<Boolean> {
+       return if (barcode != null && barcode.contains("AppId") && barcode.contains("ClientId")
+               && barcode.contains("AuthorizationEndpointUrl")
+               && barcode.contains("ServerUrl") && barcode.contains("RedirectUrl")
+               && barcode.contains("TokenUrl")) {
+           ServiceResult.SUCCESS(true)
+       } else {
+           ServiceResult.FAILURE("")
+       }
+   }
+   ```
 
 3.  The **`FlowActionHandler`** provides two methods related to handling the certificate:
 
@@ -269,12 +269,12 @@ This section provides some sample implementations for the methods in the **`Flow
 
     For example, you can create a **`SslClientAuth`** instance using a **`ChooseCertificateProvider`** instance to pop up a dialog for user to choose a certificate:
 
-    ```Kotlin
-    override fun onCertificateSslClientAuthPrepared(): SslClientAuth {
-        val chooseCertificateProvider = ChooseCertificateProvider()
-        return SslClientAuth(chooseCertificateProvider)
-    }
-    ```
+   ```Kotlin
+   override fun onCertificateSslClientAuthPrepared(): SslClientAuth {
+       val chooseCertificateProvider = ChooseCertificateProvider()
+       return SslClientAuth(chooseCertificateProvider)
+   }
+   ```
 
 4.  The **`FlowActionHandler`** provides two methods for user name and email obfuscation when displaying the information on the sign-in screen:
 
@@ -284,22 +284,22 @@ This section provides some sample implementations for the methods in the **`Flow
 
     For example, you can choose to not obfuscate the email but obfuscate the user name by keeping the first two characters and replacing the other characters with several "\_" characters:
 
-    ```Kotlin
-    override fun obfuscateEmail(email: String): String {
-        return email
-    }
+   ```Kotlin
+   override fun obfuscateEmail(email: String): String {
+       return email
+   }
 
-    override fun obfuscateUserName(name: String): String {
-        if (name.isEmpty()) {
-            return name
-        }
-        return if (name.length > 2) {
-            name.substring(0, 2) + "____"
-        } else {
-            name.substring(0, 1) + "_____"
-        }
-    }
-    ```
+   override fun obfuscateUserName(name: String): String {
+       if (name.isEmpty()) {
+           return name
+       }
+       return if (name.length > 2) {
+           name.substring(0, 2) + "____"
+       } else {
+           name.substring(0, 1) + "_____"
+       }
+   }
+   ```
 
 5.  The **`FlowActionHandler`** provides a method for the client code to add "back button press" logic when a web view is displayed for authentication. For some authentication types, the onboarding flow will open a web view for authentication. You can add your own logic to specify what action is taken when the **`Back`** button of the web view is pressed.
 
@@ -307,21 +307,21 @@ This section provides some sample implementations for the methods in the **`Flow
 
     The following sample code implements a warning dialog when the **`Back`** button is pressed:
 
-    ```Kotlin
-     override fun webViewBackPressHandler() = IBackPress {
-        val activity = AppLifecycleCallbackHandler.getInstance().activity
-        activity?.let {
-            AlertDialog.Builder(activity)
-                .setMessage("Are you sure you want to exit onboarding flow?")
-                .setPositiveButton("OK") { dialog, _ ->
-                    activity.finish()
-                    dialog.dismiss()
-                }.setNegativeButton("Cancel") { dialog, _ ->
-                    dialog.dismiss()
-                }.show()
-        }
-    }
-    ```
+   ```Kotlin
+    override fun webViewBackPressHandler() = IBackPress {
+       val activity = AppLifecycleCallbackHandler.getInstance().activity
+       activity?.let {
+           AlertDialog.Builder(activity)
+               .setMessage("Are you sure you want to exit onboarding flow?")
+               .setPositiveButton("OK") { dialog, _ ->
+                   activity.finish()
+                   dialog.dismiss()
+               }.setNegativeButton("Cancel") { dialog, _ ->
+                   dialog.dismiss()
+               }.show()
+       }
+   }
+   ```
 
 6.  The **`FlowActionHandler`** provides a method for the client code to add custom steps for the onboarding flow. The client code can add its own steps to the supported insert points.
 
@@ -329,43 +329,43 @@ This section provides some sample implementations for the methods in the **`Flow
 
     Currently, the following insertion points are supported：
 
-    ```Kotlin
-    sealed class CustomStepInsertionPoint {
-        object BeforeEula : CustomStepInsertionPoint()
-        object BeforeActivation : CustomStepInsertionPoint()
-        object BeforeAuthentication : CustomStepInsertionPoint()
-        object BeforeSetPasscode : CustomStepInsertionPoint()
-        object BeforeConsents : CustomStepInsertionPoint()
-        object BeforeOnboardingFinish : CustomStepInsertionPoint()
-    }
-    ```
+   ```Kotlin
+   sealed class CustomStepInsertionPoint {
+       object BeforeEula : CustomStepInsertionPoint()
+       object BeforeActivation : CustomStepInsertionPoint()
+       object BeforeAuthentication : CustomStepInsertionPoint()
+       object BeforeSetPasscode : CustomStepInsertionPoint()
+       object BeforeConsents : CustomStepInsertionPoint()
+       object BeforeOnboardingFinish : CustomStepInsertionPoint()
+   }
+   ```
 
-    The following sample code adds a welcome step before the EULA step for the onboarding flow：
+   The following sample code adds a welcome step before the EULA step for the onboarding flow：
 
-    ```Kotlin
-    override fun getFlowCustomizationSteps(
-        flow: BaseFlow,
-        insertionPoint: CustomStepInsertionPoint
-    ) {
-        if (flow.flowName == FlowType.Onboarding.name) {
-            when (insertionPoint) {
-                CustomStepInsertionPoint.BeforeEula -> {
-                    flow.addSingleStep(step_welcome, secure = false) {
-                        LaunchScreen(
-                            primaryViewClickListener = {
-                                flow.flowDone(step_welcome)
-                            },
-                            secondaryViewClickListener = {
-                                flow.terminateFlow(Activity.RESULT_OK)
-                            }
-                        )
-                    }
-                }
-                else -> Unit
-            }
-        }
-    }
-    ```
+   ```Kotlin
+   override fun getFlowCustomizationSteps(
+       flow: BaseFlow,
+       insertionPoint: CustomStepInsertionPoint
+   ) {
+       if (flow.flowName == FlowType.Onboarding.name) {
+           when (insertionPoint) {
+               CustomStepInsertionPoint.BeforeEula -> {
+                   flow.addSingleStep(step_welcome, secure = false) {
+                       LaunchScreen(
+                           primaryViewClickListener = {
+                               flow.flowDone(step_welcome)
+                           },
+                           secondaryViewClickListener = {
+                               flow.terminateFlow(Activity.RESULT_OK)
+                           }
+                       )
+                   }
+               }
+               else -> Unit
+           }
+       }
+   }
+   ```
 
 Congratulations! You have learned how to customize a Jetpack Compose onboarding flow!
 

--- a/tutorials/sdk-android-flowsjc-passcode/sdk-android-flowsjc-passcode.md
+++ b/tutorials/sdk-android-flowsjc-passcode/sdk-android-flowsjc-passcode.md
@@ -32,29 +32,29 @@ primary_tag: products>sap-btp-sdk-for-android
 
     !![Change passcode flow](change-passcode-kotlin.png)
 
-    ```Kotlin
-    private fun startChangePasscodeFlow(
-        context: Context,
-        launchScope: CoroutineScope,
-        snackbarHostState: SnackbarHostState
-    ) {
-        val flowContext =
-            FlowContextRegistry.flowContext.copy(
-                flowType = FlowType.ChangePasscode,
-                flow = null
-            )
-        FlowUtil.startFlow(context = context, flowContext = flowContext) { resultCode, _ ->
-            if (resultCode == Activity.RESULT_OK) {
-                launchScope.launch {
-                    snackbarHostState.showSnackbar(
-                        message = "Passcode changed",
-                        duration = SnackbarDuration.Short
-                    )
-                }
-            }
-        }
-    }
-    ```
+   ```Kotlin
+   private fun startChangePasscodeFlow(
+       context: Context,
+       launchScope: CoroutineScope,
+       snackbarHostState: SnackbarHostState
+   ) {
+       val flowContext =
+           FlowContextRegistry.flowContext.copy(
+               flowType = FlowType.ChangePasscode,
+               flow = null
+           )
+       FlowUtil.startFlow(context = context, flowContext = flowContext) { resultCode, _ ->
+           if (resultCode == Activity.RESULT_OK) {
+               launchScope.launch {
+                   snackbarHostState.showSnackbar(
+                       message = "Passcode changed",
+                       duration = SnackbarDuration.Short
+                   )
+               }
+           }
+       }
+   }
+   ```
 
 4.  The change passcode flow will firstly display the sign-in screen for the user to input their current passcode. When sign-in is successful with correct passcode, a set passcode flow will be started and open "Create Passcode" and "Verify Passcode" screens for user to input and verify the new passcode. The subsequent step is optional, when biometric authentication is enabled in the passcode policy and is also supported on the device, the "Enable Biometric" screen will be displayed. The user can decide whether or not to enable biometric authentication for this app. Then the flow is finished and the new passcode will take effect.
 

--- a/tutorials/sdk-android-flowsjc-restore/sdk-android-flowsjc-restore.md
+++ b/tutorials/sdk-android-flowsjc-restore/sdk-android-flowsjc-restore.md
@@ -41,25 +41,25 @@ The flows component will automatically determine whether to use the onboarding o
 
     !![Flow restore starting method](flowjc-restore-kotlin.png)
 
-    ```Kotlin
-    fun startOnboarding(context: Context, appConfig: AppConfig) {
-        TimeoutLockService.updateApplicationLockState(true)
-        WelcomeActivity.logger.debug("Before starting flow, lock state: {}", ApplicationStates.applicationLocked)
-        FlowUtil.startFlow(
-            context,
-            flowContext = getOnboardingFlowContext(context, appConfig)
-        ) { resultCode, data ->
-            if (resultCode == Activity.RESULT_OK) {
-                onlineInitializationAfterOnboarding(context) {
-                    launchMainBusinessActivity(context)
-                }
-                WelcomeActivity.logger.debug("After flow, lock state: {}",  ApplicationStates.applicationLocked)
-            } else {
-                startOnboarding(context, appConfig)
-            }
-        }
-    }
-    ```
+   ```Kotlin
+   fun startOnboarding(context: Context, appConfig: AppConfig) {
+       TimeoutLockService.updateApplicationLockState(true)
+       WelcomeActivity.logger.debug("Before starting flow, lock state: {}", ApplicationStates.applicationLocked)
+       FlowUtil.startFlow(
+           context,
+           flowContext = getOnboardingFlowContext(context, appConfig)
+       ) { resultCode, data ->
+           if (resultCode == Activity.RESULT_OK) {
+               onlineInitializationAfterOnboarding(context) {
+                   launchMainBusinessActivity(context)
+               }
+               WelcomeActivity.logger.debug("After flow, lock state: {}",  ApplicationStates.applicationLocked)
+           } else {
+               startOnboarding(context, appConfig)
+           }
+       }
+   }
+   ```
 
 4.  The restore flow will notify the same events as the onboarding flow and one additional `UnlockWithPasscode` event, which is specific to the restore flow. When the app is unlocked using a passcode, the client code can get the passcode from the `onUnlockWithPasscode` callback of the `FlowStateListener` instance and open the secure store. [Customize the Jetpack Compose Onboarding Flow](sdk-android-flowsjc-onboarding) explains the events notified in the onboarding flow.
 
@@ -79,20 +79,20 @@ There may be occasions when the user wants to reset the app to its initial state
 
     !![App reset flow](app-reset-kotlin.png)
 
-    ```Kotlin
-    private fun startResetAppFlow(context: Context) {
-        FlowUtil.startFlow(
-            context = context,
-            flowContext = FlowContextRegistry.flowContext.copy(
-                flowType = FlowType.Reset, flow = null
-            )
-        ) { resultCode, _ ->
-            if (resultCode == Activity.RESULT_OK) {
-                launchWelcomeActivity(context)
-            }
-        }
-    }
-    ```
+   ```Kotlin
+   private fun startResetAppFlow(context: Context) {
+       FlowUtil.startFlow(
+           context = context,
+           flowContext = FlowContextRegistry.flowContext.copy(
+               flowType = FlowType.Reset, flow = null
+           )
+       ) { resultCode, _ ->
+           if (resultCode == Activity.RESULT_OK) {
+               launchWelcomeActivity(context)
+           }
+       }
+   }
+   ```
 
 4.  When the reset flow is started, the default behavior is for a dialog to be displayed, asking the user for confirmation.
 
@@ -100,23 +100,23 @@ There may be occasions when the user wants to reset the app to its initial state
 
     You can customize your client code so that the reset flow hides this dialog by setting the  **`skip`** parameter to **`true`** for the bundle **`skipConfirmForResetFlow`** and populating this customized bundle with the **`updateIntent`**  parameter to start the reset flow.
 
-    ```Kotlin
-    FlowUtil.startFlow(
-        context = context,
-        flowContext = FlowContextRegistry.flowContext.copy(
-            flowType = FlowType.Reset, flow = null
-        ),
-        updateIntent = { intent ->
-            intent.populateCustomBundle {
-                skipConfirmForResetFlow(skip = true)
-            }
-        }
-    ) { resultCode, _ ->
-        if (resultCode == Activity.RESULT_OK) {
-            launchWelcomeActivity(context)
-        }
-    }
-    ```
+   ```Kotlin
+   FlowUtil.startFlow(
+       context = context,
+       flowContext = FlowContextRegistry.flowContext.copy(
+           flowType = FlowType.Reset, flow = null
+       ),
+       updateIntent = { intent ->
+           intent.populateCustomBundle {
+               skipConfirmForResetFlow(skip = true)
+           }
+       }
+   ) { resultCode, _ ->
+       if (resultCode == Activity.RESULT_OK) {
+           launchWelcomeActivity(context)
+       }
+   }
+   ```
 
 5.  Before removing all the data managed by the Flows component, the reset flow will notify the `ApplicationReset` event. You can use the `onApplicationReset` callback of the `FlowStateListener` instance to insert its own logic for application reset, for example to clear the data managed by the client code and reset the mobile services added to the application.
 
@@ -124,11 +124,11 @@ There may be occasions when the user wants to reset the app to its initial state
 
     !![App reset listener](app-reset-listener.png)
 
-    ```Kotlin
-    override suspend fun onApplicationReset() {
-        this.application.resetApplication()
-    }
-    ```
+   ```Kotlin
+   override suspend fun onApplicationReset() {
+       this.application.resetApplication()
+   }
+   ```
 
 [ACCORDION-END]
 
@@ -144,21 +144,21 @@ The logout flow will try to log out the current user if the network is available
 
     !![Flow logout starting method](flow-logout-kotlin.png)
 
-    ```Kotlin
-    fun StartLogoutFlow() {
-        val context = LocalContext.current
-        FlowUtil.startFlow(
-            context = context,
-            flowContext = FlowContextRegistry.flowContext.copy(
-                flowType = FlowType.Logout, flow = null
-            )
-        ) { resultCode, _ ->
-            if (resultCode == Activity.RESULT_OK) {
-                launchWelcomeActivity(context)
-            }
-        }
-    }
-    ```
+   ```Kotlin
+   fun StartLogoutFlow() {
+       val context = LocalContext.current
+       FlowUtil.startFlow(
+           context = context,
+           flowContext = FlowContextRegistry.flowContext.copy(
+               flowType = FlowType.Logout, flow = null
+           )
+       ) { resultCode, _ ->
+           if (resultCode == Activity.RESULT_OK) {
+               launchWelcomeActivity(context)
+           }
+       }
+   }
+   ```
 
 4.  When the logout flow is started, the default behavior is for a dialog to be displayed, asking the user for confirmation.
 
@@ -166,38 +166,38 @@ The logout flow will try to log out the current user if the network is available
 
      You can customize your client code so that the logout flow hides this dialog by setting the  **`skip`** parameter to **`true`** for the bundle **`skipConfirmForLogoutFlow`** and populating this customized bundle with the **`updateIntent`** parameter to start the logout flow.
 
-    ```Kotlin
-    FlowUtil.startFlow(
-        context = context,
-        flowContext = FlowContextRegistry.flowContext.copy(
-            flowType = FlowType.Logout, flow = null
-        ),
-        updateIntent = { intent ->
-            intent.populateCustomBundle {
-                skipConfirmForLogoutFlow(skip = true)
-            }
-        }
-    ) { resultCode, _ ->
-        if (resultCode == Activity.RESULT_OK) {
-            launchWelcomeActivity(context)
-        }
-    }
-    ```
+   ```Kotlin
+   FlowUtil.startFlow(
+       context = context,
+       flowContext = FlowContextRegistry.flowContext.copy(
+           flowType = FlowType.Logout, flow = null
+       ),
+       updateIntent = { intent ->
+           intent.populateCustomBundle {
+               skipConfirmForLogoutFlow(skip = true)
+           }
+       }
+   ) { resultCode, _ ->
+       if (resultCode == Activity.RESULT_OK) {
+           launchWelcomeActivity(context)
+       }
+   }
+   ```
 
 5.  The logout flow will not automatically remove the push registration. The client code can implement the **`FlowActivityResultCallback`** callback function to delete the Firebase push token if it does not want to receive push notifications after logout. The logout flow will trigger the callback function after a successful logout.
 
-    ```Kotlin
-    FlowUtil.startFlow(
-        context = context,
-        flowContext = FlowContextRegistry.flowContext.copy(
-            flowType = FlowType.Logout, flow = null
-        )
-    ) { resultCode, _ ->
-        if (resultCode == Activity.RESULT_OK) {
-            SDKInitializer.getService(FirebasePushService::class)?.stopPush()
-        }
-    }
-    ```
+   ```Kotlin
+   FlowUtil.startFlow(
+       context = context,
+       flowContext = FlowContextRegistry.flowContext.copy(
+           flowType = FlowType.Logout, flow = null
+       )
+   ) { resultCode, _ ->
+       if (resultCode == Activity.RESULT_OK) {
+           SDKInitializer.getService(FirebasePushService::class)?.stopPush()
+       }
+   }
+   ```
 
 [ACCORDION-END]
 
@@ -213,21 +213,21 @@ The delete registration flow will delete the registration of the current user on
 
     !![Flow delete registration starting method](flow-delreg-kotlin.png)
 
-    ```Kotlin
-    private fun startDeleteRegFlow(context: Context, finishCallback: (Int)-> Unit = {}) {
-        FlowUtil.startFlow(
-            context = context,
-            flowContext = FlowContextRegistry.flowContext.copy(
-                flowType = FlowType.DeleteRegistration, flow = null
-            )
-        ) { resultCode, _ ->
-            finishCallback(resultCode)
-            if (resultCode == Activity.RESULT_OK) {
-            launchWelcomeActivity(context)
-            }
-        }
-    }
-    ```
+   ```Kotlin
+   private fun startDeleteRegFlow(context: Context, finishCallback: (Int)-> Unit = {}) {
+       FlowUtil.startFlow(
+           context = context,
+           flowContext = FlowContextRegistry.flowContext.copy(
+               flowType = FlowType.DeleteRegistration, flow = null
+           )
+       ) { resultCode, _ ->
+           finishCallback(resultCode)
+           if (resultCode == Activity.RESULT_OK) {
+           launchWelcomeActivity(context)
+           }
+       }
+   }
+   ```
 
 4.  When the delete registration flow is started, the default behavior is for a dialog to be displayed, asking the user for confirmation.
 
@@ -235,23 +235,23 @@ The delete registration flow will delete the registration of the current user on
 
      You can customize your client code so that the delete registration flow hides this dialog by setting the **`skip`** parameter to **`true`** for the **`skipConfirmForDeleteRegistrationFlow`** bundle and populating this customized bundle with the parameter **`updateIntent`** to start the delete registration flow.
 
-    ```Kotlin
-    FlowUtil.startFlow(
-        context = context,
-        flowContext = FlowContextRegistry.flowContext.copy(
-            flowType = FlowType.DeleteRegistration, flow = null
-        ),
-        updateIntent = { intent ->
-            intent.populateCustomBundle {
-                skipConfirmForDeleteRegistrationFlow(skip = true)
-            }
-        }
-    ) { resultCode, _ ->
-        if (resultCode == Activity.RESULT_OK) {
-            launchWelcomeActivity(context)
-        }
-    }
-    ```
+   ```Kotlin
+   FlowUtil.startFlow(
+       context = context,
+       flowContext = FlowContextRegistry.flowContext.copy(
+           flowType = FlowType.DeleteRegistration, flow = null
+       ),
+       updateIntent = { intent ->
+           intent.populateCustomBundle {
+               skipConfirmForDeleteRegistrationFlow(skip = true)
+           }
+       }
+   ) { resultCode, _ ->
+       if (resultCode == Activity.RESULT_OK) {
+           launchWelcomeActivity(context)
+       }
+   }
+   ```
 
 Congratulations! You now have learned how to restore, reset, logout and delete the user registration of an application using the Jetpack Compose Flows component!
 

--- a/tutorials/sdk-android-flowsjc-wizard/sdk-android-flowsjc-wizard.md
+++ b/tutorials/sdk-android-flowsjc-wizard/sdk-android-flowsjc-wizard.md
@@ -46,27 +46,27 @@ The [Jetpack Compose Flows](https://help.sap.com/doc/f53c64b93e5140918d676b927a3
 
     !![JC Flow starting method](flow-starting-JC.png)
 
-    ```Kotlin
-    fun startOnboarding(context: Context, appConfig: AppConfig) {
-        TimeoutLockService.updateApplicationLockState(true)
-        WelcomeActivity.logger.debug("Before starting flow, lock state: {}", ApplicationStates.applicationLocked)
-        FlowUtil.startFlow(
-            context,
-            flowContext = getOnboardingFlowContext(context, appConfig)
-        ) { resultCode, data ->
-            if (resultCode == Activity.RESULT_OK) {
-                onlineInitializationAfterOnboarding(context) {
-                    launchMainBusinessActivity(context)
-                }
-                WelcomeActivity.logger.debug("After flow, lock state: {}",  ApplicationStates.applicationLocked)
-            } else {
-                startOnboarding(context, appConfig)
-            }
-        }
-    }
-    ```
+   ```Kotlin
+   fun startOnboarding(context: Context, appConfig: AppConfig) {
+       TimeoutLockService.updateApplicationLockState(true)
+       WelcomeActivity.logger.debug("Before starting flow, lock state: {}", ApplicationStates.applicationLocked)
+       FlowUtil.startFlow(
+           context,
+           flowContext = getOnboardingFlowContext(context, appConfig)
+       ) { resultCode, data ->
+           if (resultCode == Activity.RESULT_OK) {
+               onlineInitializationAfterOnboarding(context) {
+                   launchMainBusinessActivity(context)
+               }
+               WelcomeActivity.logger.debug("After flow, lock state: {}",  ApplicationStates.applicationLocked)
+           } else {
+               startOnboarding(context, appConfig)
+           }
+       }
+   }
+   ```
 
-    Notice that by default, the type of a flow is **`FlowType.ONBOARDING`**. To start a different type of flow, such as a `Change Passcode` flow, the client code must specify the flow type in the **`FlowContext`** instance. Besides the parameters specified above, there are also many other parameters in the **`FlowContext`** class that can be modified to allow the client code to customize a flow. When the values of the parameters are not specified in the client code, the default values will be used. The details of all parameters in the **`FlowContext`** class will be explained in subsequent tutorials.
+   Notice that by default, the type of a flow is **`FlowType.ONBOARDING`**. To start a different type of flow, such as a `Change Passcode` flow, the client code must specify the flow type in the **`FlowContext`** instance. Besides the parameters specified above, there are also many other parameters in the **`FlowContext`** class that can be modified to allow the client code to customize a flow. When the values of the parameters are not specified in the client code, the default values will be used. The details of all parameters in the **`FlowContext`** class will be explained in subsequent tutorials.
 
 4.  **`FlowStateListener`** is a parameter in the **`FlowContext`** class. In Android Studio, on Windows, press **`Ctrl+N`**, or, on a Mac, press **`command+O`**, and type **`WizardFlowStateListener`** to open `WizardFlowStateListener.kt`. This class is a sample implementation for the callbacks defined in the **`FlowStateListener`** class. The callback functions in 'FlowStateListener' and the execution sequences are the same as in view-based Flows, but all of them are marked 'suspend' in the Compose version of Flows. This will make the client code easier to execute logic in different Dispatchers, and also make the execution sequence easier to manage. The details of **`FlowState`** and **`FlowStateListener`** will be explained in subsequent tutorials.
 

--- a/tutorials/sdk-android-wizard-app-customize/sdk-android-wizard-app-customize.md
+++ b/tutorials/sdk-android-wizard-app-customize/sdk-android-wizard-app-customize.md
@@ -40,23 +40,23 @@ time: 60
 
     The category name is displayed (rather than the product name) because the app was generated from the OData service's metadata, which does not specify which of the many fields from the product entity to display. When creating the sample user interface, the SDK wizard uses the first property found as the value to display. To view the complete metadata document, open the `res/raw/com_sap_edm_sampleservice_v4.xml` file.
 
-    ```XML
-    <EntityType Name="Product">
-        <Key>
-            <PropertyRef Name="ProductID"/>
-        </Key>
-        <Property Name="Category" Type="Edm.String" Nullable="true" MaxLength="40"/>
-        ... ...
-        <Property Name="Name" Type="Edm.String" Nullable="false" MaxLength="80"/>
-        ... ...
-    </EntityType>
-    ```
+   ```XML
+   <EntityType Name="Product">
+       <Key>
+           <PropertyRef Name="ProductID"/>
+       </Key>
+       <Property Name="Category" Type="Edm.String" Nullable="true" MaxLength="40"/>
+       ... ...
+       <Property Name="Name" Type="Edm.String" Nullable="false" MaxLength="80"/>
+       ... ...
+   </EntityType>
+   ```
 
-    Each product is displayed in an [object cell](https://help.sap.com/doc/f53c64b93e5140918d676b927a3cd65b/Cloud/en-US/docs-en/guides/features/fiori-ui/android/object-cell.html), which is one of the Fiori UI controls for Android.
+   Each product is displayed in an [object cell](https://help.sap.com/doc/f53c64b93e5140918d676b927a3cd65b/Cloud/en-US/docs-en/guides/features/fiori-ui/android/object-cell.html), which is one of the Fiori UI controls for Android.
 
-    ![object cell](object-cell.png)
+   ![object cell](object-cell.png)
 
-    As seen above, an object cell is used to display information about an entity.
+   As seen above, an object cell is used to display information about an entity.
 
 
 ### Update the products list screen
@@ -76,27 +76,27 @@ In this section, you will configure the object cell to display a product's name,
 
 3.  In the same code block, replace `setSubheadline` and `setFootnote`, and add `setStatusInfoLabel` with the following code, which will display the category, description, and price.
 
-    ```Kotlin
-    setSubheadline(entity.getDataValue(Product.category).toString())
-    setFootnote(entity.getDataValue(Product.shortDescription).toString())
-    setStatusInfoLabel(
-        FioriStatusInfoLabelDataInOC(
-            items = listOf(
-                FioriLabelItemData(
-                    label = "$ ${entity.getDataValue(Product.price).toString()}"
-                )
-            )
-        )
-    )
-    ```
+   ```Kotlin
+   setSubheadline(entity.getDataValue(Product.category).toString())
+   setFootnote(entity.getDataValue(Product.shortDescription).toString())
+   setStatusInfoLabel(
+       FioriStatusInfoLabelDataInOC(
+           items = listOf(
+               FioriLabelItemData(
+                   label = "$ ${entity.getDataValue(Product.price).toString()}"
+               )
+           )
+       )
+   )
+   ```
 
 4.  On Windows, press **`Ctrl+F`**, or on a Mac, press **`command+F`**, and type **`FioriObjectCell`** to navigate to the `FioriObjectCell` invocation.
 
 5.  Add the following code right after `FioriObjectCell` invocation, and add it right before `if (entities.loadState.refresh == LoadState.Loading)` at the same time, to add a divider between the product items.
 
-    ```Kotlin
-    FioriDivider()
-    ```
+   ```Kotlin
+   FioriDivider()
+   ```
 
 6.  On Windows, press **`Ctrl+N`**, or on a Mac, press **`command+O`**, and type **`Repository`** to open `Repository.kt`.
 
@@ -104,14 +104,14 @@ In this section, you will configure the object cell to display a product's name,
 
 8.  Replace the `orderByProperty?.also` block with the following code to specify that the sort order should be by category and then by the name of the products.
 
-    ```Kotlin
-    orderByProperty?.also {
-        dataQuery.orderBy(it, SortOrder.ASCENDING)
-        if (entitySet.entityType == ESPMContainerMetadata.EntityTypes.product) {
-            dataQuery.thenBy(Product.name, SortOrder.ASCENDING)
-        }
-    }
-    ```
+   ```Kotlin
+   orderByProperty?.also {
+       dataQuery.orderBy(it, SortOrder.ASCENDING)
+       if (entitySet.entityType == ESPMContainerMetadata.EntityTypes.product) {
+           dataQuery.thenBy(Product.name, SortOrder.ASCENDING)
+       }
+   }
+   ```
 
 9.  Quit the app and then re-run it. You'll see that the **Products** screen has been updated to display the product's name, category, description, and price, with the entries sorted by category and then by name.
 
@@ -125,51 +125,51 @@ In this section, you will configure the object cell to display a product's name,
 
 2.  On Windows, press **`Ctrl+F12`**, or on a Mac, press **`command+F12`**, and type **`populateObjectCell`** to navigate to the `populateObjectCell` method. Change the parameter in the first line of the method from **`getOptionalValue(Product.category)`** to **`getOptionalValue(Product.name)`**. This will ensure that the product name is displayed as the headline value of the object cell:
 
-    ```Kotlin
-    val dataValue = productEntity.getOptionalValue(Product.name)
-    ```
+   ```Kotlin
+   val dataValue = productEntity.getOptionalValue(Product.name)
+   ```
 
 3.  Replace the `viewHolder.objectCell.apply` block with the following code, which will display the category, description, and price.
 
-    ```Kotlin
-    viewHolder.objectCell.apply {
-      headline = masterPropertyValue
-      setUseCutOut(false)
+   ```Kotlin
+   viewHolder.objectCell.apply {
+     headline = masterPropertyValue
+     setUseCutOut(false)
 
-      (productEntity.getDataValue(Product.category))?.let {
-        subheadline = it.toString()
-      }
+     (productEntity.getDataValue(Product.category))?.let {
+       subheadline = it.toString()
+     }
 
-      (productEntity.getDataValue(Product.shortDescription))?.let {
-        footnote = it.toString()
-      }
+     (productEntity.getDataValue(Product.shortDescription))?.let {
+       footnote = it.toString()
+     }
 
-      (productEntity.getDataValue(Product.price))?.let {
-        statusWidth = 200
-        setStatus("$ $it", 1)
-      }
-    }
-    ```
+     (productEntity.getDataValue(Product.price))?.let {
+       statusWidth = 200
+       setStatus("$ $it", 1)
+     }
+   }
+   ```
 
 4.  On Windows, press **`Ctrl+F12`**, or on a Mac, press **`command+F12`**, and type **`onViewStateRestored`** to navigate to the `onViewStateRestored` method.
 
 5.  Replace `fragmentBinding.itemList?.let` block with the following code, which adds a divider between product items.
 
-    ```Kotlin
-    fragmentBinding.itemList.let {
-        val linearLayoutManager = LinearLayoutManager(currentActivity)
-        val dividerItemDecoration =
-            DividerItemDecoration(it.context, linearLayoutManager.orientation)
-        it.addItemDecoration(dividerItemDecoration)
-        it.layoutManager = linearLayoutManager
-        this.adapter = ProductListAdapter(currentActivity, it)
-        it.adapter = this.adapter
-    }
-    ```
+   ```Kotlin
+   fragmentBinding.itemList.let {
+       val linearLayoutManager = LinearLayoutManager(currentActivity)
+       val dividerItemDecoration =
+           DividerItemDecoration(it.context, linearLayoutManager.orientation)
+       it.addItemDecoration(dividerItemDecoration)
+       it.layoutManager = linearLayoutManager
+       this.adapter = ProductListAdapter(currentActivity, it)
+       it.adapter = this.adapter
+   }
+   ```
 
-    If the classes `LinearLayoutManager` and `DividerItemDecoration` appear in red, it indicates that Android Studio could not locate them. Select each class, and on Windows, press **`Alt+Enter`**, or on a Mac, press **`option+return`** to use Android Studio's quick fix to add the missing imports.
+   If the classes `LinearLayoutManager` and `DividerItemDecoration` appear in red, it indicates that Android Studio could not locate them. Select each class, and on Windows, press **`Alt+Enter`**, or on a Mac, press **`option+return`** to use Android Studio's quick fix to add the missing imports.
 
-    Alternatively, you can enable the following setting: Windows: **Settings**; Mac: **Android Studio > Settings...**. Then go to **Editor > General > Auto Import**, enable **Add unambiguous imports on the fly** in the `Kotlin` section.
+   Alternatively, you can enable the following setting: Windows: **Settings**; Mac: **Android Studio > Settings...**. Then go to **Editor > General > Auto Import**, enable **Add unambiguous imports on the fly** in the `Kotlin` section.
 
 6.  On Windows, press **`Ctrl+N`**, or on a Mac, press **`command+O`**, and type **`Repository`** to open `Repository.kt`.
 
@@ -177,14 +177,14 @@ In this section, you will configure the object cell to display a product's name,
 
 8.  Replace the `if (!entitySet.isSingleton && orderByProperty != null)` block with the following code to specify that the sort order should be by category and then by the name of the products.
 
-    ```Kotlin
-    if (!entitySet.isSingleton && orderByProperty != null) {
-        dataQuery = dataQuery.orderBy(orderByProperty, SortOrder.ASCENDING)
-        if (entitySet.entityType == ESPMContainerMetadata.EntityTypes.product) {
-            dataQuery.thenBy(Product.name, SortOrder.ASCENDING)
-        }
-    }
-    ```
+   ```Kotlin
+   if (!entitySet.isSingleton && orderByProperty != null) {
+       dataQuery = dataQuery.orderBy(orderByProperty, SortOrder.ASCENDING)
+       if (entitySet.entityType == ESPMContainerMetadata.EntityTypes.product) {
+           dataQuery.thenBy(Product.name, SortOrder.ASCENDING)
+       }
+   }
+   ```
 
 9.  Quit the app and then re-run it. You'll see that the **Products** screen has been updated to display the product's name, category, description, and price, with the entries sorted by category and then by name.
 
@@ -207,9 +207,9 @@ In this section, you will update the screen's title, configure the object cell t
 
 2.  Add the following entry:
 
-    ```XML
-    <string name="product_categories_title">Product Categories</string>
-    ```
+   ```XML
+   <string name="product_categories_title">Product Categories</string>
+   ```
 
 3.  On Windows, press **`Ctrl+Shift+N`**, or on a Mac, press **`command+shift+O`**, and type **`ProductCategoryEntitiesScreen`**, to open `ProductCategoryEntitiesScreen.kt`.
 
@@ -219,38 +219,38 @@ In this section, you will update the screen's title, configure the object cell t
 
 6.  Add the following line right after the commented-out line to set the screen's title:
 
-    ```Kotlin
-    title = stringResource(id = R.string.product_categories_title),
-    ```
+   ```Kotlin
+   title = stringResource(id = R.string.product_categories_title),
+   ```
 
 7.  On Windows, press **`Ctrl+F`**, or on a Mac, press **`command+F`**, and type **`FioriObjectCell`** to navigate to the `FioriObjectCell` invocation. 
 
 8.  Add the following code right after `FioriObjectCell` invocation and add it right before `if (entities.loadState.refresh == LoadState.Loading)` at the same time, which adds a divider between categories:
 
-    ```Kotlin
-    FioriDivider()
-    ```
+   ```Kotlin
+   FioriDivider()
+   ```
 
 9.  On Windows, press **`Ctrl+F`**, or on a Mac, press **`command+F`**, and type **`FioriObjectCellData`**, to move to the `FioriObjectCellData` code block.
 
 10. Replace the value of `objectCellData` with the following to display the main category instead, hide the footnote, and show the number of products per category.
 
-    ```Kotlin
-    val objectCellData = FioriObjectCellData.Builder().apply {
-        setHeadline(viewModel.getEntityTitle(entity))
-        setSubheadline(entity.getDataValue(ProductCategory.mainCategoryName).toString())
-        setAvatar(avatar)
-        setStatusInfoLabel(
-            FioriStatusInfoLabelDataInOC(
-                items = listOf(
-                    FioriLabelItemData(
-                        label = "${entity.getDataValue(ProductCategory.numberOfProducts).toString()} Products"
-                    )
-                )
-            )
-        )
-    }.build()
-    ```
+   ```Kotlin
+   val objectCellData = FioriObjectCellData.Builder().apply {
+       setHeadline(viewModel.getEntityTitle(entity))
+       setSubheadline(entity.getDataValue(ProductCategory.mainCategoryName).toString())
+       setAvatar(avatar)
+       setStatusInfoLabel(
+           FioriStatusInfoLabelDataInOC(
+               items = listOf(
+                   FioriLabelItemData(
+                       label = "${entity.getDataValue(ProductCategory.numberOfProducts).toString()} Products"
+                   )
+               )
+           )
+       )
+   }.build()
+   ```
 
 11. Run the app again. You'll see that the **title**, **subheadline**, and **status** are now displayed, while the **icon** and **footnote** are no longer visible.
 
@@ -270,9 +270,9 @@ In this section, you will update the screen's title, configure the object cell t
 
 2.  Add the following entry:
 
-    ```XML
-    <string name="product_categories_title">Product Categories</string>
-    ```
+   ```XML
+   <string name="product_categories_title">Product Categories</string>
+   ```
 
 3.  On Windows, press **`Ctrl+N`**, or on a Mac, press **`command+O`**, and type **`ProductCategoriesListFragment`**, to open `ProductCategoriesListFragment.kt`.
 
@@ -282,46 +282,46 @@ In this section, you will update the screen's title, configure the object cell t
 
 6.  Add the following line right after the commented-out line to set the screen's title:
 
-    ```Kotlin
-    currentActivity.title = resources.getString(R.string.product_categories_title)
-    ```
+   ```Kotlin
+   currentActivity.title = resources.getString(R.string.product_categories_title)
+   ```
 
 7.  Still in this method, replace the `fragmentBinding.itemList?.let` block with the following code, which adds a divider between categories:
 
-    ```Kotlin
-    fragmentBinding.itemList.let {
-        val linearLayoutManager = LinearLayoutManager(currentActivity)
-        val dividerItemDecoration =
-            DividerItemDecoration(it.context, linearLayoutManager.orientation)
-        it.addItemDecoration(dividerItemDecoration)
-        it.layoutManager = linearLayoutManager
-        this.adapter = ProductCategoryListAdapter(currentActivity, it)
-        it.adapter = this.adapter
-    }
-    ```
+   ```Kotlin
+   fragmentBinding.itemList.let {
+       val linearLayoutManager = LinearLayoutManager(currentActivity)
+       val dividerItemDecoration =
+           DividerItemDecoration(it.context, linearLayoutManager.orientation)
+       it.addItemDecoration(dividerItemDecoration)
+       it.layoutManager = linearLayoutManager
+       this.adapter = ProductCategoryListAdapter(currentActivity, it)
+       it.adapter = this.adapter
+   }
+   ```
 
 8.  On Windows, press **`Ctrl+F12`**, or on a Mac, press **`command+F12`**, and type **`populateObjectCell`**, to move to the `populateObjectCell` method.
 
 9.  Replace the `viewHolder.objectCell.apply` block with the following to display the main category instead, hide the footnote, and show the number of products per category.
 
-    ```Kotlin
-    viewHolder.objectCell.apply {
-      headline = masterPropertyValue
-      detailImage = null
-      setDetailImage(viewHolder, productCategoryEntity)
+   ```Kotlin
+   viewHolder.objectCell.apply {
+     headline = masterPropertyValue
+     detailImage = null
+     setDetailImage(viewHolder, productCategoryEntity)
 
-      (productCategoryEntity.getDataValue(ProductCategory.mainCategoryName))?.let {
-        subheadline = it.toString()
-      }
+     (productCategoryEntity.getDataValue(ProductCategory.mainCategoryName))?.let {
+       subheadline = it.toString()
+     }
 
-      lines = 2  //Not using footnote
+     lines = 2  //Not using footnote
 
-      (productCategoryEntity.getDataValue(ProductCategory.numberOfProducts))?.let {
-        statusWidth = 220
-        setStatus("$it Products", 1)
-      }
-    }
-    ```
+     (productCategoryEntity.getDataValue(ProductCategory.numberOfProducts))?.let {
+       statusWidth = 220
+       setStatus("$it Products", 1)
+     }
+   }
+   ```
 
 10. Run the app again. You'll see that the **title**, **subheadline**, and **status** are now displayed, while the **icon** and **footnote** are no longer visible.
 
@@ -341,34 +341,34 @@ In this section, you will modify the app to initially show the **Product Categor
 
 2. Change the `startDestination` of `NavHost` to:
 
-    ```Kotlin
-    EntityNavigationCommands(ESPMContainerMetadata.EntityTypes.productCategory).entityListNav.route
-    ```
+   ```Kotlin
+   EntityNavigationCommands(ESPMContainerMetadata.EntityTypes.productCategory).entityListNav.route
+   ```
 
     Add the following composable content before `composable(route = EntitySetsDest.route)` code block:
 
-    ```Kotlin
-    composable(route = EntityNavigationCommands(ESPMContainerMetadata.EntityTypes.productCategory).entityListNav.route) {
-        val viewModel: ODataViewModel<EntityValue> = viewModel(
-            factory = ODataEntityViewModelFactory(
-                LocalContext.current.applicationContext as Application,
-                ESPMContainerMetadata.EntityTypes.productCategory,
-                ESPMContainerMetadata.EntitySets.productCategories,
-                getOrderByProperty(ESPMContainerMetadata.EntityTypes.productCategory),
-            )
-        )
+   ```Kotlin
+   composable(route = EntityNavigationCommands(ESPMContainerMetadata.EntityTypes.productCategory).entityListNav.route) {
+       val viewModel: ODataViewModel<EntityValue> = viewModel(
+           factory = ODataEntityViewModelFactory(
+               LocalContext.current.applicationContext as Application,
+               ESPMContainerMetadata.EntityTypes.productCategory,
+               ESPMContainerMetadata.EntitySets.productCategories,
+               getOrderByProperty(ESPMContainerMetadata.EntityTypes.productCategory),
+           )
+       )
 
-        ODataScreen(
-            navController,
-            isExpandedScreen,
-            viewModel,
-            ProductCategoryEntitiesExpandScreen,
-            ProductCategoryEntitiesScreen,
-            ProductCategoryEntityEditScreen,
-            ProductCategoryEntityDetailScreen
-        )
-    }
-    ```
+       ODataScreen(
+           navController,
+           isExpandedScreen,
+           viewModel,
+           ProductCategoryEntitiesExpandScreen,
+           ProductCategoryEntitiesScreen,
+           ProductCategoryEntityEditScreen,
+           ProductCategoryEntityDetailScreen
+       )
+   }
+   ```
 
     This will cause the **Product Categories** screen to be the first screen seen when opening the app. 
 
@@ -378,115 +378,115 @@ In this section, you will modify the app to initially show the **Product Categor
 
 5. Replace the `onFloatingAdd` function with the following code:
 
-    ```Kotlin
-    open fun onFloatingAdd(): (() -> Unit)? {
-        val action = {
-            onCreateAction()
-            refreshEntities()
-        }
+   ```Kotlin
+   open fun onFloatingAdd(): (() -> Unit)? {
+       val action = {
+           onCreateAction()
+           refreshEntities()
+       }
 
-        return parent?.let { parent ->
-            return navigationPropertyName?.let {
-                val navProp = parent.entityType.getProperty(navigationPropertyName)
-                val navValue = parent.getOptionalValue(navProp)
-                if (navProp.isEntityList || navProp.isComplexList || navValue == null) action else null
-            } ?: action
-        } ?: action
-    }
-    ```
+       return parent?.let { parent ->
+           return navigationPropertyName?.let {
+               val navProp = parent.entityType.getProperty(navigationPropertyName)
+               val navValue = parent.getOptionalValue(navProp)
+               if (navProp.isEntityList || navProp.isComplexList || navValue == null) action else null
+           } ?: action
+       } ?: action
+   }
+   ```
 
 6. On Windows, press **`Ctrl+Shift+N`**, or on a Mac, press **`command+Shift+O`**, and type **`ProductEntitiesScreen`**, to open `ProductEntitiesScreen.kt`.
 
 7. Add a variable in the method body, after the variable "viewModel", to retrive the selected category name from `ODataViewModel`:
 
-    ```Kotlin
-    val category = (viewModel.parent as? ProductCategory)?.categoryName
-    ```
+   ```Kotlin
+   val category = (viewModel.parent as? ProductCategory)?.categoryName
+   ```
 
 8. On Windows, press **`Ctrl+F`**, or on a Mac, press **`command+F`**, and type **`return@items`** to locate the line `val entity = entities[index] ?: return@items`. Immediately after this line, add the following code to filter the products list to display only the products for the selected category:
 
-    ```Kotlin
-    category?.also {
-        if((entity as Product).category != it) {
-            return@items
-        }
-    }
-    ```
+   ```Kotlin
+   category?.also {
+       if((entity as Product).category != it) {
+           return@items
+       }
+   }
+   ```
 
 9. On Windows, press **`Ctrl+Shift+N`**, or on a Mac, press **`command+Shift+O`**, and type **`ODataNavHost`**, to open `ODataNavHost.kt`.
 
 10. Replace the `if (!uiState.isEntityFocused)` block with the following:
     
-    ```Kotlin
-    if (!uiState.isEntityFocused) {
-        entityListScreen(
-            {
-                if ((viewModel as EntityViewModel).entityType != ESPMContainerMetadata.EntityTypes.productCategory) {
-                    navController.navigate(EntitySetsDest.route)
-                }
-            },
-            {
-                if ((viewModel as EntityViewModel).entityType == ESPMContainerMetadata.EntityTypes.productCategory) {
-                    navController.navigate(EntitySetsDest.route)
-                } else {
-                    navController.navigateUp()
-                }
-            },
-            viewModel,
-            false
-        )
-    }
-    ```
+   ```Kotlin
+   if (!uiState.isEntityFocused) {
+       entityListScreen(
+           {
+               if ((viewModel as EntityViewModel).entityType != ESPMContainerMetadata.EntityTypes.productCategory) {
+                   navController.navigate(EntitySetsDest.route)
+               }
+           },
+           {
+               if ((viewModel as EntityViewModel).entityType == ESPMContainerMetadata.EntityTypes.productCategory) {
+                   navController.navigate(EntitySetsDest.route)
+               } else {
+                   navController.navigateUp()
+               }
+           },
+           viewModel,
+           false
+       )
+   }
+   ```
 
-    You can navigate to the **EntityList** screen by pressing the **Back** button on the **Product Categories** screen. The **EntityList** screen retains the **Settings** menu for convenience.
+   You can navigate to the **EntityList** screen by pressing the **Back** button on the **Product Categories** screen. The **EntityList** screen retains the **Settings** menu for convenience.
 
 11. Replace the `EntityOperationType.DETAIL` code block with the following, which will enable the navigation from the Category list screen to the Product list screen.
 
-    ```Kotlin
-    EntityOperationType.DETAIL -> if ((viewModel as EntityViewModel).entityType == ESPMContainerMetadata.EntityTypes.productCategory) {
-        viewModel.lostEntityFocus()
-        val productCategory = uiState.masterEntity as ProductCategory
-        navController.currentBackStackEntry?.savedStateHandle?.set(
-            key = "productCategory", value = productCategory
-        )
-        navController.navigate(EntityNavigationCommands(ESPMContainerMetadata.EntityTypes.product).entityListNav.route)
-    } else {
-        entityDetailScreen(
-            onNavigateProperty,
-            viewModel::lostEntityFocus,
-            viewModel,
-            false
-        )
-    }
-    ```
+   ```Kotlin
+   EntityOperationType.DETAIL -> if ((viewModel as EntityViewModel).entityType == ESPMContainerMetadata.EntityTypes.productCategory) {
+       viewModel.lostEntityFocus()
+       val productCategory = uiState.masterEntity as ProductCategory
+       navController.currentBackStackEntry?.savedStateHandle?.set(
+           key = "productCategory", value = productCategory
+       )
+       navController.navigate(EntityNavigationCommands(ESPMContainerMetadata.EntityTypes.product).entityListNav.route)
+   } else {
+       entityDetailScreen(
+           onNavigateProperty,
+           viewModel::lostEntityFocus,
+           viewModel,
+           false
+       )
+   }
+   ```
 
 12. Replace the `composable(route = EntityNavigationCommands(entityType).entityListNav.route)` block with the following code so that the product screen can retrieve the selected category name:
 
-    ```Kotlin
-    composable(route = EntityNavigationCommands(entityType).entityListNav.route) {
-        ODataScreen(
-            navController,
-            isExpandedScreen,
-            viewModel(
-                factory = ODataEntityViewModelFactory(
-                    LocalContext.current.applicationContext as Application,
-                    entityType,
-                    entitySet,
-                    getOrderByProperty(entityType),
-                    if (entityType == ESPMContainerMetadata.EntityTypes.product)
-                        navController.previousBackStackEntry?.savedStateHandle?.get<ProductCategory>(
-                            "productCategory"
-                        )
-                    else null
-                )
-            ),
-            entityExpandScreen,
-            entityListScreen,
-            entityEditScreen,
-            entityDetailScreen
-        )
-    }
-    ```
+   ```Kotlin
+   composable(route = EntityNavigationCommands(entityType).entityListNav.route) {
+       ODataScreen(
+           navController,
+           isExpandedScreen,
+           viewModel(
+               factory = ODataEntityViewModelFactory(
+                   LocalContext.current.applicationContext as Application,
+                   entityType,
+                   entitySet,
+                   getOrderByProperty(entityType),
+                   if (entityType == ESPMContainerMetadata.EntityTypes.product)
+                       navController.previousBackStackEntry?.savedStateHandle?.get<ProductCategory>(
+                           "productCategory"
+                       )
+                   else null
+               )
+           ),
+           entityExpandScreen,
+           entityListScreen,
+           entityEditScreen,
+           entityDetailScreen
+       )
+   }
+   ```
 
 13. On Windows, press **`Ctrl+Shift+N`**, or on a Mac, press **`command+Shift+O`**, and type **`ProductCategoryEntitiesScreen`**, to open `ProductCategoryEntitiesScreen.kt`.
 
@@ -496,9 +496,9 @@ In this section, you will modify the app to initially show the **Product Categor
 
 16. Find the `ActionItem` of `R.string.menu_home` and change its overflowMode to the following:
 
-    ```Kotlin
-    overflowMode = if((viewModel as EntityViewModel).entityType == ESPMContainerMetadata.EntityTypes.productCategory) OverflowMode.NOT_SHOWN else OverflowMode.IF_NECESSARY,
-    ```
+   ```Kotlin
+   overflowMode = if((viewModel as EntityViewModel).entityType == ESPMContainerMetadata.EntityTypes.productCategory) OverflowMode.NOT_SHOWN else OverflowMode.IF_NECESSARY,
+   ```
 
 17. Run the app again. You'll see that the **Product Categories** screen is now the first screen displayed, the **Home** menu is no longer visible, and selecting a category shows the products list screen, which now displays only the products for that selected category.
 
@@ -514,15 +514,15 @@ In this section, you will modify the app to initially show the **Product Categor
 
 3. Add the following line below the other Intent declaration:
 
-    ```Kotlin
-    val pcIntent = Intent(this, ProductCategoriesActivity::class.java)
-    ```
+   ```Kotlin
+   val pcIntent = Intent(this, ProductCategoriesActivity::class.java)
+   ```
 
 4. After the call to `startActivity(intent)`, add the following line:
 
-    ```Kotlin
-    startActivity(pcIntent)
-    ```
+   ```Kotlin
+   startActivity(pcIntent)
+   ```
 
     This will cause the **Product Categories** screen to be the first screen seen when opening the app, but because the **EntityList** screen is opened first, it can be navigated to by pressing the **Back** button. The **EntityList** screen retains the **Settings** menu for convenience.
 
@@ -532,58 +532,58 @@ In this section, you will modify the app to initially show the **Product Categor
 
 7. Replace the `fragmentBinding.fab?.let` block with the following code:
 
-    ```Kotlin
-    fragmentBinding.fab?.let {createButton ->
-        parentEntityData?.let {parent ->
-            navigationPropertyName?.let {
-                if (!isNavigationPropertyConnection && entityList.isNotEmpty()){
-                    createButton.hide()
-                } else {
-                    createButton.show()
-                }
-            }
-        }
-    }
-    ```
+   ```Kotlin
+   fragmentBinding.fab?.let {createButton ->
+       parentEntityData?.let {parent ->
+           navigationPropertyName?.let {
+               if (!isNavigationPropertyConnection && entityList.isNotEmpty()){
+                   createButton.hide()
+               } else {
+                   createButton.show()
+               }
+           }
+       }
+   }
+   ```
 
 8. Add the `onCreateMenu` method into the class right after the `onCreateView` method.
    
-    ```Kotlin
-    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
-        super.onCreateMenu(menu, menuInflater)
-        menu.removeItem(R.id.menu_home)
-    }
-    ```
+   ```Kotlin
+   override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+       super.onCreateMenu(menu, menuInflater)
+       menu.removeItem(R.id.menu_home)
+   }
+   ```
 
 9. On Windows, press **`Ctrl+F12`**, or on a Mac, press **`command+F12`**, and type **`setOnClickListener`**, to move to the `setOnClickListener` method.
 
 10. Replace the code with the following, which will enable the navigation from the Category list screen to the Product list screen.
 
-    ```Kotlin
-    holder.itemView.setOnClickListener { view ->
-        val productsIntent = Intent(currentActivity, ProductsActivity::class.java)
-        productsIntent.putExtra("category", productCategoryEntity.categoryName)
-        view.context.startActivity(productsIntent)
-    }
-    ```
+   ```Kotlin
+   holder.itemView.setOnClickListener { view ->
+       val productsIntent = Intent(currentActivity, ProductsActivity::class.java)
+       productsIntent.putExtra("category", productCategoryEntity.categoryName)
+       view.context.startActivity(productsIntent)
+   }
+   ```
 
 11. On Windows, press **`Ctrl+N`**, or on a Mac, press **`command+O`**, and type **`ProductsListFragment`**, to open `ProductsListFragment.kt`.
 
 12. On Windows, press **`Ctrl+F`**, or on a Mac, press **`command+F`**, and search for `listAdapter.setItems(entityList)`. Replace that line with the following code, which will filter the products list to display only the products for the selected category:
 
-    ```Kotlin
-    currentActivity.intent.getStringExtra("category")?.let { category ->
-        val matchingProducts = arrayListOf<Product>()
-        for (product in entityList) {
-            product.category?.let {
-                if (it == category) {
-                  matchingProducts.add(product)
-                }
-            }
-        }
-        listAdapter.setItems(matchingProducts)
-    } ?: listAdapter.setItems(entityList)
-    ```
+   ```Kotlin
+   currentActivity.intent.getStringExtra("category")?.let { category ->
+       val matchingProducts = arrayListOf<Product>()
+       for (product in entityList) {
+           product.category?.let {
+               if (it == category) {
+                 matchingProducts.add(product)
+               }
+           }
+       }
+       listAdapter.setItems(matchingProducts)
+   } ?: listAdapter.setItems(entityList)
+   ```
 
 13. Run the app again. You'll see that the **Product Categories** screen is now the first screen displayed, the **Home** menu is no longer visible, and selecting a category shows the products list screen, which now displays only the products for that selected category.
 
@@ -601,66 +601,66 @@ In this section you will add a search field to **Product Categories** screen, al
 
 1.  First, right-click the `res/drawable` folder to create a new **Drawable Resource File** **`ic_search_icon.xml`**, and use the following XML content.
 
-    ```XML
-    <?xml version="1.0" encoding="utf-8"?>
-    <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
-        android:height="24dp"
-        android:viewportWidth="24"
-        android:viewportHeight="24">
-        <path
-            android:fillColor="#000"
-            android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
-    </vector>
-    ```
+   ```XML
+   <?xml version="1.0" encoding="utf-8"?>
+   <vector xmlns:android="http://schemas.android.com/apk/res/android"
+       android:width="24dp"
+       android:height="24dp"
+       android:viewportWidth="24"
+       android:viewportHeight="24">
+       <path
+           android:fillColor="#000"
+           android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
+   </vector>
+   ```
 
-    We will now use the new XML file for the **Product Categories** screen.
+   We will now use the new XML file for the **Product Categories** screen.
 
 2.  On Windows, press **`Ctrl+Shift+N`**, or on a Mac, press **`command+Shift+O`**, and type **`strings_localized`**, to open the `strings_localized.xml` file.
 
 3.  Add the following content:
     
-    ```XML
-    <!-- XMIT: Search menu item -->
-    <string name="menu_search">Search</string>
-    ```
+   ```XML
+   <!-- XMIT: Search menu item -->
+   <string name="menu_search">Search</string>
+   ```
 
 4.  On Windows, press **`Ctrl+N`**, or on a Mac, press **`command+O`**, and type **`BaseOperationViewModel`**, to open the `BaseOperationViewModel` class.
 
 5.  Add the following to the bottom of the class:
 
-    ```Kotlin
-    private val _showSearchInput = MutableStateFlow(false)
-    val showSearchInput: StateFlow<Boolean> = _showSearchInput
-    private val _searchQuery = MutableStateFlow("")
-    val searchQuery: StateFlow<String> = _searchQuery
+   ```Kotlin
+   private val _showSearchInput = MutableStateFlow(false)
+   val showSearchInput: StateFlow<Boolean> = _showSearchInput
+   private val _searchQuery = MutableStateFlow("")
+   val searchQuery: StateFlow<String> = _searchQuery
 
-    fun showSearchInput() {
-        _showSearchInput.value = true
-    }
+   fun showSearchInput() {
+       _showSearchInput.value = true
+   }
 
-    fun hideSearchInput() {
-        _showSearchInput.value = false
-    }
+   fun hideSearchInput() {
+       _showSearchInput.value = false
+   }
 
-    fun onSearchQueryChanged(newText: String) {
-        // Handle query text change
-        _searchQuery.value = newText
-    }
-    ```
+   fun onSearchQueryChanged(newText: String) {
+       // Handle query text change
+       _searchQuery.value = newText
+   }
+   ```
 
 6.  On Windows, press **`Ctrl+Shift+N`**, or on a Mac, press **`command+Shift+O`**, and type **`EntityScreenCommonUI`**, to open the `EntityScreenCommonUI.kt` file.
 
 7.  Add the following `ActionItem` right before the other `ActionItem`s in the function `getSelectedItemActionsList(navigateToHome: () -> Unit, viewModel: ODataViewModel, deleteState: MutableState<Boolean>)`. (Note that there is another function with the same name that takes two parameters.)
 
-    ```Kotlin
-    ActionItem(
-        nameRes = R.string.menu_search,
-        iconRes = if (viewModel.showSearchInput.collectAsState().value) R.drawable.ic_sap_icon_decline else R.drawable.ic_search_icon,
-        overflowMode = if((viewModel as EntityViewModel).entityType == ESPMContainerMetadata.EntityTypes.productCategory) OverflowMode.IF_NECESSARY else OverflowMode.NOT_SHOWN,
-        doAction = if (viewModel.showSearchInput.collectAsState().value) viewModel::hideSearchInput else viewModel::showSearchInput
-    ),
-    ```
+   ```Kotlin
+   ActionItem(
+       nameRes = R.string.menu_search,
+       iconRes = if (viewModel.showSearchInput.collectAsState().value) R.drawable.ic_sap_icon_decline else R.drawable.ic_search_icon,
+       overflowMode = if((viewModel as EntityViewModel).entityType == ESPMContainerMetadata.EntityTypes.productCategory) OverflowMode.IF_NECESSARY else OverflowMode.NOT_SHOWN,
+       doAction = if (viewModel.showSearchInput.collectAsState().value) viewModel::hideSearchInput else viewModel::showSearchInput
+   ),
+   ```
 
 8.  On Windows, press **`Ctrl+Shift+N`**, or on a Mac, press **`command+Shift+O`**, and type **`BaseOperationScreen`**, to open the `BaseOperationScreen.kt` file.
 
@@ -668,102 +668,102 @@ In this section you will add a search field to **Product Categories** screen, al
 
 10. Replace the contents of the method with the following code, which uses the new `ActionItem` to enable and listen to the text entered in the `OutlinedTextField`. (Make sure to import all the un-imported classes with **`alt+Enter`** on Windows or **`option+Enter`** on Macs.)
 
-    ```Kotlin
-    @OptIn(ExperimentalMaterial3Api::class)
-    @Composable
-    fun ODataAppBar(
-        title: String,
-        modifier: Modifier = Modifier,
-        navigateUp: (() -> Unit)?,
-        actionItems: List<ActionItem>,
-        actionEnabled: Boolean = true,
-        showSearchInput: Boolean,
-        onSearchQueryChanged: (String) -> Unit
-    ) {
-        Column(modifier = Modifier) {
-            TopAppBar(
-                title = {
-                    if (showSearchInput) {
-                        //import androidx.compose.runtime.getValue
-                        //import androidx.compose.runtime.mutableStateOf
-                        //import androidx.compose.runtime.setValue
-                        var query by remember { mutableStateOf("") }
-                        OutlinedTextField(
-                            singleLine = true,
-                            value = query,
-                            onValueChange = {
-                                query = it
-                                onSearchQueryChanged(it)
-                            },
-                            label = { Text("Search") },
-                            colors = OutlinedTextFieldDefaults.colors(
-                                //import androidx.compose.ui.graphics.Color
-                                focusedBorderColor = Color.Transparent,
-                                unfocusedBorderColor = Color.Transparent,
-                                cursorColor = Color.Gray,
-                                errorCursorColor = Color.Red
-                            ),
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                    } else {
-                        Text(title)
-                    }
-                },
-                modifier = modifier,
-                navigationIcon = {
-                    navigateUp?.also {
-                        IconButton(onClick = it) {
-                            Icon(
-                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                                contentDescription = ""
-                            )
-                        }
-                    }
-                },
-                actions = { ActionMenu(actionItems, isEnabled = actionEnabled) }
-            )
-        }
-    }
-    ```
+   ```Kotlin
+   @OptIn(ExperimentalMaterial3Api::class)
+   @Composable
+   fun ODataAppBar(
+       title: String,
+       modifier: Modifier = Modifier,
+       navigateUp: (() -> Unit)?,
+       actionItems: List<ActionItem>,
+       actionEnabled: Boolean = true,
+       showSearchInput: Boolean,
+       onSearchQueryChanged: (String) -> Unit
+   ) {
+       Column(modifier = Modifier) {
+           TopAppBar(
+               title = {
+                   if (showSearchInput) {
+                       //import androidx.compose.runtime.getValue
+                       //import androidx.compose.runtime.mutableStateOf
+                       //import androidx.compose.runtime.setValue
+                       var query by remember { mutableStateOf("") }
+                       OutlinedTextField(
+                           singleLine = true,
+                           value = query,
+                           onValueChange = {
+                               query = it
+                               onSearchQueryChanged(it)
+                           },
+                           label = { Text("Search") },
+                           colors = OutlinedTextFieldDefaults.colors(
+                               //import androidx.compose.ui.graphics.Color
+                               focusedBorderColor = Color.Transparent,
+                               unfocusedBorderColor = Color.Transparent,
+                               cursorColor = Color.Gray,
+                               errorCursorColor = Color.Red
+                           ),
+                           modifier = Modifier.fillMaxWidth()
+                       )
+                   } else {
+                       Text(title)
+                   }
+               },
+               modifier = modifier,
+               navigationIcon = {
+                   navigateUp?.also {
+                       IconButton(onClick = it) {
+                           Icon(
+                               imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                               contentDescription = ""
+                           )
+                       }
+                   }
+               },
+               actions = { ActionMenu(actionItems, isEnabled = actionEnabled) }
+           )
+       }
+   }
+   ```
 
 11. On Windows, press **`Ctrl+F12`**, or on a Mac, press **`command+F12`**, and type **`OperationScreen`**, to move to the `OperationScreen` method.
 
 12. Update the `topBar` of `Scaffold` in the function `OperationScreen` accordingly.
 
-    ```Kotlin
-    topBar = {
-        ODataAppBar(
-            title = screenSettings.title,
-            modifier = modifier,
-            navigateUp = screenSettings.navigateUp,
-            actionItems = screenSettings.actionItems,
-            actionEnabled = !operationUiState.value.inProgress,
-            showSearchInput = viewModel.showSearchInput.collectAsState().value,
-            onSearchQueryChanged = viewModel::onSearchQueryChanged
-        )
-    },
-    ```
+   ```Kotlin
+   topBar = {
+       ODataAppBar(
+           title = screenSettings.title,
+           modifier = modifier,
+           navigateUp = screenSettings.navigateUp,
+           actionItems = screenSettings.actionItems,
+           actionEnabled = !operationUiState.value.inProgress,
+           showSearchInput = viewModel.showSearchInput.collectAsState().value,
+           onSearchQueryChanged = viewModel::onSearchQueryChanged
+       )
+   },
+   ```
 
 13. On Windows, press **`Ctrl+Shift+N`**, or on a Mac, press **`command+Shift+O`**, and type **`ProductCategoryEntitiesScreen`**, to open the `ProductCategoryEntitiesScreen.kt` file.
 
 14. Add the following variables.
 
-    ```Kotlin
-    val showSearchInput = viewModel.showSearchInput.collectAsState().value
-    val searchQuery = viewModel.searchQuery.collectAsState().value
-    ```
+   ```Kotlin
+   val showSearchInput = viewModel.showSearchInput.collectAsState().value
+   val searchQuery = viewModel.searchQuery.collectAsState().value
+   ```
 
 15. On Windows, press **`Ctrl+F`**, or on a Mac, press **`command+F`**, and type **`return@items`**, to find the code line `val entity = entities[index] ?: return@items`. Right after the line, add the following code to filter the product category list to display only the categories that contain the searched text:
 
-    ```Kotlin
-    if (showSearchInput) {
-        (entity as ProductCategory).categoryName?.let {
-            if (!it.lowercase().contains(searchQuery.lowercase())) {
-                return@items
-            }
-        }
-    }
-    ```
+   ```Kotlin
+   if (showSearchInput) {
+       (entity as ProductCategory).categoryName?.let {
+           if (!it.lowercase().contains(searchQuery.lowercase())) {
+               return@items
+           }
+       }
+   }
+   ```
 
 16. Run the app again. You'll notice that there is now a search toolbar item.
 
@@ -779,104 +779,104 @@ In this section you will add a search field to **Product Categories** screen, al
 
 1.  First, right-click the `res/drawable` folder to create a new **Drawable Resource File** **`ic_search_icon.xml`**, and use the following XML content.
 
-    ```XML
-    <?xml version="1.0" encoding="utf-8"?>
-    <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
-        android:height="24dp"
-        android:viewportWidth="24"
-        android:viewportHeight="24">
-        <path
-            android:fillColor="#000"
-            android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
-    </vector>
-    ```
+   ```XML
+   <?xml version="1.0" encoding="utf-8"?>
+   <vector xmlns:android="http://schemas.android.com/apk/res/android"
+       android:width="24dp"
+       android:height="24dp"
+       android:viewportWidth="24"
+       android:viewportHeight="24">
+       <path
+           android:fillColor="#000"
+           android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
+   </vector>
+   ```
 
-    The current menu `res/menu/itemlist_menu.xml` is shared among all list screens. We will now use a new XML file for the **Product Categories** screen.
+   The current menu `res/menu/itemlist_menu.xml` is shared among all list screens. We will now use a new XML file for the **Product Categories** screen.
 
 2.  Right-click the `res/menu` folder to add a new **Menu Resource File** named **`product_categories_menu.xml`**, and use the following XML for its contents.
 
-    ```XML
-    <?xml version="1.0" encoding="utf-8"?>
-    <menu xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto">
+   ```XML
+   <?xml version="1.0" encoding="utf-8"?>
+   <menu xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:app="http://schemas.android.com/apk/res-auto">
 
-        <item
-            android:id="@+id/action_search"
-            android:icon="@drawable/ic_search_icon"
-            android:title="Search"
-            app:actionViewClass="com.sap.cloud.mobile.fiori.search.FioriSearchView"
-            app:showAsAction="always|collapseActionView"
-            style="@style/FioriSearchView" />
+       <item
+           android:id="@+id/action_search"
+           android:icon="@drawable/ic_search_icon"
+           android:title="Search"
+           app:actionViewClass="com.sap.cloud.mobile.fiori.search.FioriSearchView"
+           app:showAsAction="always|collapseActionView"
+           style="@style/FioriSearchView" />
 
-        <item
-            android:id="@+id/menu_refresh"
-            android:icon="@drawable/ic_sap_icon_refresh"
-            app:showAsAction="always"
-            android:title="@string/menu_refresh"/>
-    </menu>
-    ```
+       <item
+           android:id="@+id/menu_refresh"
+           android:icon="@drawable/ic_sap_icon_refresh"
+           app:showAsAction="always"
+           android:title="@string/menu_refresh"/>
+   </menu>
+   ```
 
 3.  On Windows, press **`Ctrl+N`**, or on a Mac, press **`command+O`**, and type **`ProductCategoryListAdapter`**, to open the `ProductCategoryListAdapter` class, which is in the `ProductCategoriesListFragment.kt` file.
 
 4.  Add the following member and methods to the top of this class.
 
-    ```Kotlin
-    var allProductCategories = listOf<ProductCategory>()
+   ```Kotlin
+   var allProductCategories = listOf<ProductCategory>()
 
-    fun setProductCategories(productCategories: MutableList<ProductCategory>) {
-        this.productCategories = productCategories
-    }
-    ```
+   fun setProductCategories(productCategories: MutableList<ProductCategory>) {
+       this.productCategories = productCategories
+   }
+   ```
 
 5.  On Windows, press **`Ctrl+F12`**, or on a Mac, press **`command+F12`**, and type **`setItems`**, to move to the `setItems` method.
 
 6.  Add the following to the top of the function:
 
-    ```Kotlin
-    if (allProductCategories.isEmpty()) {
-        allProductCategories = currentProductCategories
-    }
-    ```
+   ```Kotlin
+   if (allProductCategories.isEmpty()) {
+       allProductCategories = currentProductCategories
+   }
+   ```
 
 7. On Windows, press **`Ctrl+F12`**, or on a Mac, press **`command+F12`**, and type **`onCreateMenu`**, to move to the `onCreateMenu` method.
 
 8. Replace the contents of the method with the following code, which uses the new `product_categories_menu` and sets a listener that will filter the list of categories in the list when text is entered in the search view. (Make sure to import all the un-imported classes with **`alt+Enter`** on Windows or **`option+Enter`** on Macs.)
 
-    ```Kotlin
-    menuInflater.inflate(R.menu.product_categories_menu, menu)
-    val searchView = menu.findItem(R.id.action_search).actionView as FioriSearchView
-    searchView.setBackgroundResource(R.color.transparent)
-    // make sure to import androidx.appcompat.widget.SearchView
-    searchView.setOnQueryTextListener(object: SearchView.OnQueryTextListener {
-        override fun onQueryTextSubmit(s: String): Boolean {
-            return false
-        }
+   ```Kotlin
+   menuInflater.inflate(R.menu.product_categories_menu, menu)
+   val searchView = menu.findItem(R.id.action_search).actionView as FioriSearchView
+   searchView.setBackgroundResource(R.color.transparent)
+   // make sure to import androidx.appcompat.widget.SearchView
+   searchView.setOnQueryTextListener(object: SearchView.OnQueryTextListener {
+       override fun onQueryTextSubmit(s: String): Boolean {
+           return false
+       }
 
-        override fun onQueryTextChange(newText: String): Boolean {
-            adapter?.let { adapter ->
-                val filteredCategoriesList = mutableListOf<ProductCategory>()
-                if (newText.trim().isNotEmpty()) {
-                    for (i in adapter.allProductCategories.indices) {
-                        val pc = adapter.allProductCategories[i]
-                        pc.categoryName?.let {
-                            if (it.lowercase().contains(newText.lowercase())) {
-                                filteredCategoriesList.add(pc)
-                            }
-                        }
-                    }
-                }
-                else {
-                    for (i in adapter.allProductCategories.indices) {
-                        filteredCategoriesList.add(adapter.allProductCategories[i])
-                    }
-                }
-                adapter.setProductCategories(filteredCategoriesList)
-                return false
-            } ?: return false
-        }
-    })
-    ```
+       override fun onQueryTextChange(newText: String): Boolean {
+           adapter?.let { adapter ->
+               val filteredCategoriesList = mutableListOf<ProductCategory>()
+               if (newText.trim().isNotEmpty()) {
+                   for (i in adapter.allProductCategories.indices) {
+                       val pc = adapter.allProductCategories[i]
+                       pc.categoryName?.let {
+                           if (it.lowercase().contains(newText.lowercase())) {
+                               filteredCategoriesList.add(pc)
+                           }
+                       }
+                   }
+               }
+               else {
+                   for (i in adapter.allProductCategories.indices) {
+                       filteredCategoriesList.add(adapter.allProductCategories[i])
+                   }
+               }
+               adapter.setProductCategories(filteredCategoriesList)
+               return false
+           } ?: return false
+       }
+   })
+   ```
 
 9.  Run the app again. You'll notice that there is now a search toolbar item.
 
@@ -912,137 +912,137 @@ First, we'll generate additional sales data in the sample OData service.
 
 4.  Add the following import libraries to the top of the document:
 
-    ```Kotlin
-    import android.util.Log
-    import com.sap.cloud.android.odata.espmcontainer.ESPMContainerMetadata
-    import com.sap.cloud.android.odata.espmcontainer.SalesOrderItem
-    import com.sap.cloud.mobile.fiori.compose.objectcell.ui.FioriCollectionViewLine
-    import com.sap.cloud.mobile.kotlin.odata.DataQuery
-    import com.sap.cloud.mobile.kotlin.odata.http.HttpHeaders
-    import kotlinx.coroutines.runBlocking
-    import java.util.LinkedList
-    ```
+   ```Kotlin
+   import android.util.Log
+   import com.sap.cloud.android.odata.espmcontainer.ESPMContainerMetadata
+   import com.sap.cloud.android.odata.espmcontainer.SalesOrderItem
+   import com.sap.cloud.mobile.fiori.compose.objectcell.ui.FioriCollectionViewLine
+   import com.sap.cloud.mobile.kotlin.odata.DataQuery
+   import com.sap.cloud.mobile.kotlin.odata.http.HttpHeaders
+   import kotlinx.coroutines.runBlocking
+   import java.util.LinkedList
+   ```
 
 5.  Add the following variables to the bottom of the file:
 
-    ```Kotlin
-    private var salesList = HashMap<String, Int>()
-    private val productTracker = HashMap<String, Product>()
-    private val productCollectionViewDataList = mutableListOf<FioriCollectionViewData>()
-    private val productList = mutableListOf<Product>()
-    ```
+   ```Kotlin
+   private var salesList = HashMap<String, Int>()
+   private val productTracker = HashMap<String, Product>()
+   private val productCollectionViewDataList = mutableListOf<FioriCollectionViewData>()
+   private val productList = mutableListOf<Product>()
+   ```
 
 6. Add the following method after the new added variables:
 
-    ```Kotlin
-    // Function to query the products
-    private suspend fun queryProducts() {
-        val httpHeaders: HttpHeaders = if (EntityMediaResource.isV4(SAPServiceManager.eSPMContainer!!.metadata.versionCode) && EntityMediaResource.hasMediaResources(ESPMContainerMetadata.EntityTypes.product)) {
-            val header = HttpHeaders()
-            header.set("Accept", "application/json;odata.metadata=full")
-            header
-        } else HttpHeaders.empty
-        val queryProduct = DataQuery().orderBy(Product.productID)
-        Log.d("ProductEntitiesScreen", "CollectionView: $queryProduct")
-        SAPServiceManager.eSPMContainer?.let{
-            it.getProducts(queryProduct, httpHeaders).forEach {product ->
-                Log.d("ProductEntitiesScreen", "CollectionView ${product.name} : ${product.productID} : ${product.price}")
-                productTracker[product.productID.toString()] = product
-            }
-            Log.d("ProductEntitiesScreen", "CollectionView: size of topProducts = ${productTracker.size}")
-            //Order product list by the sorted sales list
-            for ((key, value) in salesList) {
-                val product = productTracker[key] ?: continue
-                productList.add(product)
+   ```Kotlin
+   // Function to query the products
+   private suspend fun queryProducts() {
+       val httpHeaders: HttpHeaders = if (EntityMediaResource.isV4(SAPServiceManager.eSPMContainer!!.metadata.versionCode) && EntityMediaResource.hasMediaResources(ESPMContainerMetadata.EntityTypes.product)) {
+           val header = HttpHeaders()
+           header.set("Accept", "application/json;odata.metadata=full")
+           header
+       } else HttpHeaders.empty
+       val queryProduct = DataQuery().orderBy(Product.productID)
+       Log.d("ProductEntitiesScreen", "CollectionView: $queryProduct")
+       SAPServiceManager.eSPMContainer?.let{
+           it.getProducts(queryProduct, httpHeaders).forEach {product ->
+               Log.d("ProductEntitiesScreen", "CollectionView ${product.name} : ${product.productID} : ${product.price}")
+               productTracker[product.productID.toString()] = product
+           }
+           Log.d("ProductEntitiesScreen", "CollectionView: size of topProducts = ${productTracker.size}")
+           //Order product list by the sorted sales list
+           for ((key, value) in salesList) {
+               val product = productTracker[key] ?: continue
+               productList.add(product)
 
-                val data = product.pictureUrl?.let {
-                    FioriCollectionViewData(
-                        avatarImage = FioriImage(EntityMediaResource.getMediaResourceUrl(product, SAPServiceManager.serviceRoot)!!),
-                        headline = product.name,
-                        subheadline = product.categoryName + ""
-                    )
-                } ?: FioriCollectionViewData(// No picture is available, so use a character from the product string as the image thumbnail
-                    avatarText = product.name.substring(0, 1),
-                    headline = product.name,
-                    subheadline = product.categoryName + ""
-                )
-                productCollectionViewDataList.add(data)
-            }
-        }
-    }
+               val data = product.pictureUrl?.let {
+                   FioriCollectionViewData(
+                       avatarImage = FioriImage(EntityMediaResource.getMediaResourceUrl(product, SAPServiceManager.serviceRoot)!!),
+                       headline = product.name,
+                       subheadline = product.categoryName + ""
+                   )
+               } ?: FioriCollectionViewData(// No picture is available, so use a character from the product string as the image thumbnail
+                   avatarText = product.name.substring(0, 1),
+                   headline = product.name,
+                   subheadline = product.categoryName + ""
+               )
+               productCollectionViewDataList.add(data)
+           }
+       }
+   }
 
-    // Query the SalesOrderItems and order by gross amount received from sales
-    // Change the orderBy arguments to SalesOrderItem.productID to rearrange the CollectionView order of products
-    private suspend fun querySales() {
-        val httpHeaders: HttpHeaders = if (EntityMediaResource.isV4(SAPServiceManager.eSPMContainer!!.metadata.versionCode) && EntityMediaResource.hasMediaResources(ESPMContainerMetadata.EntityTypes.salesOrderItem)) {
-            val header = HttpHeaders()
-            header.set("Accept", "application/json;odata.metadata=full")
-            header
-        } else HttpHeaders.empty
-        val querySales = DataQuery().orderBy(SalesOrderItem.productID)
-        SAPServiceManager.eSPMContainer?.let{
-            it.getSalesOrderItems(querySales, httpHeaders).forEach {sale ->
-                if (salesList.containsKey(sale.productID.toString())) {
-                    salesList[sale.productID.toString()] = salesList[sale.productID.toString()]!! + sale.quantity
-                } else {
-                    salesList[sale.productID.toString()] = sale.quantity
-                }
-                Log.d("ProductEntitiesScreen","CollectionView ${sale.productID} : ${sale.quantity} : ${sale.grossAmount}")
-            }
-            salesList = sortByValue(salesList)
-            Log.d("ProductEntitiesScreen", "CollectionView: salesList size = ${salesList.size}")
-            queryProducts()
-        }
-    }
+   // Query the SalesOrderItems and order by gross amount received from sales
+   // Change the orderBy arguments to SalesOrderItem.productID to rearrange the CollectionView order of products
+   private suspend fun querySales() {
+       val httpHeaders: HttpHeaders = if (EntityMediaResource.isV4(SAPServiceManager.eSPMContainer!!.metadata.versionCode) && EntityMediaResource.hasMediaResources(ESPMContainerMetadata.EntityTypes.salesOrderItem)) {
+           val header = HttpHeaders()
+           header.set("Accept", "application/json;odata.metadata=full")
+           header
+       } else HttpHeaders.empty
+       val querySales = DataQuery().orderBy(SalesOrderItem.productID)
+       SAPServiceManager.eSPMContainer?.let{
+           it.getSalesOrderItems(querySales, httpHeaders).forEach {sale ->
+               if (salesList.containsKey(sale.productID.toString())) {
+                   salesList[sale.productID.toString()] = salesList[sale.productID.toString()]!! + sale.quantity
+               } else {
+                   salesList[sale.productID.toString()] = sale.quantity
+               }
+               Log.d("ProductEntitiesScreen","CollectionView ${sale.productID} : ${sale.quantity} : ${sale.grossAmount}")
+           }
+           salesList = sortByValue(salesList)
+           Log.d("ProductEntitiesScreen", "CollectionView: salesList size = ${salesList.size}")
+           queryProducts()
+       }
+   }
 
-    // Function to sort hashmap by values
-    private fun sortByValue(hashmap: HashMap<String, Int>): HashMap<String, Int> {
-        // Create a list from elements of HashMap
-        val list: MutableList<Map.Entry<String, Int>> = LinkedList<Map.Entry<String, Int>>(hashmap.entries)
+   // Function to sort hashmap by values
+   private fun sortByValue(hashmap: HashMap<String, Int>): HashMap<String, Int> {
+       // Create a list from elements of HashMap
+       val list: MutableList<Map.Entry<String, Int>> = LinkedList<Map.Entry<String, Int>>(hashmap.entries)
 
-        // Sort the list
-        list.sortWith { o1, o2 -> o2.value.compareTo(o1.value) }
+       // Sort the list
+       list.sortWith { o1, o2 -> o2.value.compareTo(o1.value) }
 
-        // Put data from sorted list into the linked hashmap
-        val temp: HashMap<String, Int> = LinkedHashMap<String, Int>()
-        for ((key, value) in list) {
-            temp[key] = value
-            Log.d("ProductEntitiesScreen", "CollectionView: id = $key, count = $value")
-        }
-        return temp
-    }
-    ```
+       // Put data from sorted list into the linked hashmap
+       val temp: HashMap<String, Int> = LinkedHashMap<String, Int>()
+       for ((key, value) in list) {
+           temp[key] = value
+           Log.d("ProductEntitiesScreen", "CollectionView: id = $key, count = $value")
+       }
+       return temp
+   }
+   ```
 
 7. In the body of `ProductEntitiesScreen`, add the following variable:
 
-    ```Kotlin
-    var showCollectionView = true
-    ```
+   ```Kotlin
+   var showCollectionView = true
+   ```
 
 8. Before the `if (entities.loadState.refresh == LoadState.Loading) {` line and after `FioriDivider()`, add the following code to add a `CollectionView` to the product list screen:
 
-    ```Kotlin
-    if (showCollectionView) {
-        runBlocking {
-            querySales()
-        }
-        FioriCollectionViewLine(
-            label = "Top Products",
-            data = productCollectionViewDataList,
-            onClick = { position, _ -> // If any object is clicked in CollectionView then the Product's detail page for that object will open
-                Log.d("ProductEntitiesScreen", "You clicked on: ${productList[position].name}(${productList[position].productID})")
-                onClickChange(productList[position])
-            },
-            footerButton = FooterButton(
-                label = "SEE ALL (${productTracker.size})",
-                onClick = { // If the footer "SEE ALL" is clicked then the Products page will open
-                    showCollectionView = false
-                    viewModel.refreshEntities()
-                }),
-            scrollable = true
-        )
-    }
-    ```
+   ```Kotlin
+   if (showCollectionView) {
+       runBlocking {
+           querySales()
+       }
+       FioriCollectionViewLine(
+           label = "Top Products",
+           data = productCollectionViewDataList,
+           onClick = { position, _ -> // If any object is clicked in CollectionView then the Product's detail page for that object will open
+               Log.d("ProductEntitiesScreen", "You clicked on: ${productList[position].name}(${productList[position].productID})")
+               onClickChange(productList[position])
+           },
+           footerButton = FooterButton(
+               label = "SEE ALL (${productTracker.size})",
+               onClick = { // If the footer "SEE ALL" is clicked then the Products page will open
+                   showCollectionView = false
+                   viewModel.refreshEntities()
+               }),
+           scrollable = true
+       )
+   }
+   ```
 
 9. Run the app. You'll notice that the **Products** screen now has a component at the top of the screen that allows horizontal scrolling to view the top products. Tap a product to see more details. Alternatively, tap **SEE ALL** to see all the products.
 
@@ -1068,86 +1068,86 @@ First, we'll generate additional sales data in the sample OData service.
 
 4.  Replace the `fragment_entityitem_list.xml` content with the following code. This adds the `CollectionView` to the **Products** pane when created.
 
-    ```XML
-    <?xml version="1.0" encoding="utf-8"?>
-    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+   ```XML
+   <?xml version="1.0" encoding="utf-8"?>
+   <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:app="http://schemas.android.com/apk/res-auto"
+       xmlns:tools="http://schemas.android.com/tools"
+       android:layout_width="match_parent"
+       android:layout_height="match_parent">
 
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/fab"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom|end"
-            android:layout_margin="@dimen/fab_margin"
-            android:src="@drawable/ic_sap_icon_add"
-            app:tint="@color/colorWhite"
-            app:backgroundTint="?attr/sap_fiori_color_accent_7"
-            app:fabSize="normal" />
+       <com.google.android.material.floatingactionbutton.FloatingActionButton
+           android:id="@+id/fab"
+           android:layout_width="wrap_content"
+           android:layout_height="wrap_content"
+           android:layout_gravity="bottom|end"
+           android:layout_margin="@dimen/fab_margin"
+           android:src="@drawable/ic_sap_icon_add"
+           app:tint="@color/colorWhite"
+           app:backgroundTint="?attr/sap_fiori_color_accent_7"
+           app:fabSize="normal" />
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical"
-            android:id="@+id/wrapperLayout" >
+       <LinearLayout
+           android:layout_width="match_parent"
+           android:layout_height="match_parent"
+           android:orientation="vertical"
+           android:id="@+id/wrapperLayout" >
 
-            <com.sap.cloud.mobile.fiori.object.CollectionView
-                app:layout_scrollFlags="scroll|enterAlways"
-                android:id="@+id/collectionView"
-                android:layout_height="wrap_content"
-                android:layout_width="match_parent"
-                android:background="@color/transparent"
-                tools:minHeight="200dp">
-            </com.sap.cloud.mobile.fiori.object.CollectionView>
+           <com.sap.cloud.mobile.fiori.object.CollectionView
+               app:layout_scrollFlags="scroll|enterAlways"
+               android:id="@+id/collectionView"
+               android:layout_height="wrap_content"
+               android:layout_width="match_parent"
+               android:background="@color/transparent"
+               tools:minHeight="200dp">
+           </com.sap.cloud.mobile.fiori.object.CollectionView>
 
-            <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-                android:id="@+id/swiperefresh"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent">
+           <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+               android:id="@+id/swiperefresh"
+               android:layout_width="match_parent"
+               android:layout_height="match_parent">
 
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/item_list"
-                    android:name="ItemListFragment"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
-            </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+               <androidx.recyclerview.widget.RecyclerView
+                   android:id="@+id/item_list"
+                   android:name="ItemListFragment"
+                   android:layout_width="match_parent"
+                   android:layout_height="match_parent"
+                   app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+           </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-        </LinearLayout>
+       </LinearLayout>
 
-    </FrameLayout>
-    ```
+   </FrameLayout>
+   ```
 
 5.  On Windows, press **`Ctrl+N`**, or on a Mac, press **`command+O`**, and type **`ProductsListFragment`**, to open `ProductsListFragment.kt`.
 
 6.  Add the following import libraries to the top of the document:
 
-    ```Kotlin
-    import android.widget.LinearLayout
-    import androidx.fragment.app.FragmentActivity
-    import com.sap.cloud.android.odata.espmcontainer.SalesOrderItem
-    import com.sap.cloud.mobile.fiori.common.FioriItemClickListener
-    import com.sap.cloud.mobile.fiori.`object`.AbstractEntityCell
-    import com.sap.cloud.mobile.fiori.`object`.CollectionView
-    import com.sap.cloud.mobile.fiori.`object`.CollectionViewItem
-    import com.sap.cloud.mobile.odata.DataQuery
-    import com.sap.cloud.mobile.odata.http.HttpHeaders
+   ```Kotlin
+   import android.widget.LinearLayout
+   import androidx.fragment.app.FragmentActivity
+   import com.sap.cloud.android.odata.espmcontainer.SalesOrderItem
+   import com.sap.cloud.mobile.fiori.common.FioriItemClickListener
+   import com.sap.cloud.mobile.fiori.`object`.AbstractEntityCell
+   import com.sap.cloud.mobile.fiori.`object`.CollectionView
+   import com.sap.cloud.mobile.fiori.`object`.CollectionViewItem
+   import com.sap.cloud.mobile.odata.DataQuery
+   import com.sap.cloud.mobile.odata.http.HttpHeaders
 
-    import java.util.*
-    import kotlin.collections.ArrayList
-    import kotlin.collections.HashMap
-    import kotlin.collections.LinkedHashMap
-    ```
+   import java.util.*
+   import kotlin.collections.ArrayList
+   import kotlin.collections.HashMap
+   import kotlin.collections.LinkedHashMap
+   ```
 
 7.  Add the following variables to the top of the `ProductsListFragment` class:
 
-    ```Kotlin
-    private val productList = arrayListOf<Product>()
-    private var salesList = HashMap<String, Int>()
-    private val productTracker = HashMap<String, Product>()
-    ```
+   ```Kotlin
+   private val productList = arrayListOf<Product>()
+   private var salesList = HashMap<String, Int>()
+   private val productTracker = HashMap<String, Product>()
+   ```
 
 8.  On Windows, press **`ctrl+F12`**, or on a Mac, press **`command+F12`**, and type **`resetSelected`**, to move to the `resetSelected` method.
 
@@ -1157,207 +1157,207 @@ First, we'll generate additional sales data in the sample OData service.
 
 11. Add the following method to the `companion object` section:
 
-    ```Kotlin
-    // Function to sort hashmap by values
-    fun sortByValue(hashmap: HashMap<String, Int>): HashMap<String, Int> {
-        // Create a list from elements of HashMap
-        val list: MutableList<Map.Entry<String, Int>> = LinkedList<Map.Entry<String, Int>>(hashmap.entries)
+   ```Kotlin
+   // Function to sort hashmap by values
+   fun sortByValue(hashmap: HashMap<String, Int>): HashMap<String, Int> {
+       // Create a list from elements of HashMap
+       val list: MutableList<Map.Entry<String, Int>> = LinkedList<Map.Entry<String, Int>>(hashmap.entries)
 
-        // Sort the list
-        list.sortWith { o1, o2 ->
-            o2.value.compareTo(o1.value)
-        }
+       // Sort the list
+       list.sortWith { o1, o2 ->
+           o2.value.compareTo(o1.value)
+       }
 
-        // Put data from sorted list into the linked hashmap
-        val temp: HashMap<String, Int> = LinkedHashMap<String, Int>()
-        for ((key, value) in list) {
-            temp[key] = value
-            LOGGER.debug("CollectionView: id = $key, count = $value")
-        }
-        return temp
-    }
-    ```
+       // Put data from sorted list into the linked hashmap
+       val temp: HashMap<String, Int> = LinkedHashMap<String, Int>()
+       for ((key, value) in list) {
+           temp[key] = value
+           LOGGER.debug("CollectionView: id = $key, count = $value")
+       }
+       return temp
+   }
+   ```
 
 12. Add the following methods to the class:
 
-    ```Kotlin
-    // Function to query the products
-    private fun queryProducts() {
-        val sapServiceManager = (currentActivity.application as SAPWizardApplication).sapServiceManager
-        val query = DataQuery().orderBy(Product.productID)
-        LOGGER.debug("CollectionView $query")
-        val espmContainer = sapServiceManager?.eSPMContainer
-        espmContainer?.let {
-            val httpHeaders: HttpHeaders = if (EntityMediaResource.isV4(it.metadata.versionCode) && EntityMediaResource.hasMediaResources(EntityTypes.product)) {
-                val header = HttpHeaders()
-                header.set("Accept", "application/json;odata.metadata=full")
-                header
-            } else HttpHeaders.empty
-            it.getProductsAsync(query, {queryProducts: List<Product> ->
-                LOGGER.debug("CollectionView: executed query in onCreate")
-                for (product in queryProducts) {
-                    LOGGER.debug("CollectionView ${product.name} : ${product.productID} : ${product.price}")
-                    productTracker[product.productID.toString()] = product
-                }
+   ```Kotlin
+   // Function to query the products
+   private fun queryProducts() {
+       val sapServiceManager = (currentActivity.application as SAPWizardApplication).sapServiceManager
+       val query = DataQuery().orderBy(Product.productID)
+       LOGGER.debug("CollectionView $query")
+       val espmContainer = sapServiceManager?.eSPMContainer
+       espmContainer?.let {
+           val httpHeaders: HttpHeaders = if (EntityMediaResource.isV4(it.metadata.versionCode) && EntityMediaResource.hasMediaResources(EntityTypes.product)) {
+               val header = HttpHeaders()
+               header.set("Accept", "application/json;odata.metadata=full")
+               header
+           } else HttpHeaders.empty
+           it.getProductsAsync(query, {queryProducts: List<Product> ->
+               LOGGER.debug("CollectionView: executed query in onCreate")
+               for (product in queryProducts) {
+                   LOGGER.debug("CollectionView ${product.name} : ${product.productID} : ${product.price}")
+                   productTracker[product.productID.toString()] = product
+               }
 
-                LOGGER.debug("CollectionView: size of topProducts = ${queryProducts.size}")
-                createTopProductsList()
-                val cv: CollectionView = currentActivity.findViewById(R.id.collectionView)
-                createCollectionView(cv)
-            }, {re: RuntimeException -> LOGGER.debug("CollectionView: An error occurred during products async query: ${re.message}")
-            }, httpHeaders)
-        }
-    }
+               LOGGER.debug("CollectionView: size of topProducts = ${queryProducts.size}")
+               createTopProductsList()
+               val cv: CollectionView = currentActivity.findViewById(R.id.collectionView)
+               createCollectionView(cv)
+           }, {re: RuntimeException -> LOGGER.debug("CollectionView: An error occurred during products async query: ${re.message}")
+           }, httpHeaders)
+       }
+   }
 
-    // Function to order product list by the sorted sales list
-    private fun createTopProductsList() {
-      for ((key, value) in salesList) {
-        productList.add(productTracker[key]!!)
-      }
-    }
+   // Function to order product list by the sorted sales list
+   private fun createTopProductsList() {
+     for ((key, value) in salesList) {
+       productList.add(productTracker[key]!!)
+     }
+   }
 
-    // Function to set features of the CollectionView
-    private fun createCollectionView(cv: CollectionView) {
-        LOGGER.debug("CollectionView: in createCollectionView method")
-        cv.apply {
-          setHeader(" Top Products")
-          setFooter(" SEE ALL (${productTracker.size})")
+   // Function to set features of the CollectionView
+   private fun createCollectionView(cv: CollectionView) {
+       LOGGER.debug("CollectionView: in createCollectionView method")
+       cv.apply {
+         setHeader(" Top Products")
+         setFooter(" SEE ALL (${productTracker.size})")
 
-          // If the footer "SEE ALL" is clicked then the Products page will open
-          setFooterClickListener {
-              visibility = View.GONE
-          }
+         // If the footer "SEE ALL" is clicked then the Products page will open
+         setFooterClickListener {
+             visibility = View.GONE
+         }
 
-          // If any object is clicked in CollectionView then the Product's detail page for that object will open
-          setItemClickListener(object: FioriItemClickListener {
-              override fun onClick(view: View, position: Int) {
-                  LOGGER.debug("You clicked on: ${productList[position].name}(${productList[position].productID})")
-                  showProductDetailActivity(view.context, UIConstants.OP_READ, productList[position])
-              }
+         // If any object is clicked in CollectionView then the Product's detail page for that object will open
+         setItemClickListener(object: FioriItemClickListener {
+             override fun onClick(view: View, position: Int) {
+                 LOGGER.debug("You clicked on: ${productList[position].name}(${productList[position].productID})")
+                 showProductDetailActivity(view.context, UIConstants.OP_READ, productList[position])
+             }
 
-              override fun onLongClick(view: View, position: Int) {
-                  Toast.makeText(currentActivity.applicationContext, "You long clicked on: $position", Toast.LENGTH_SHORT).show()
-              }
-          })
+             override fun onLongClick(view: View, position: Int) {
+                 Toast.makeText(currentActivity.applicationContext, "You long clicked on: $position", Toast.LENGTH_SHORT).show()
+             }
+         })
 
-          val collectionViewAdapter = CollectionViewAdapter(currentActivity, productList.toList())
-          setCollectionViewAdapter(collectionViewAdapter)
-        }
+         val collectionViewAdapter = CollectionViewAdapter(currentActivity, productList.toList())
+         setCollectionViewAdapter(collectionViewAdapter)
+       }
 
-        if (resources.getBoolean(R.bool.two_pane)) {
-            refreshLayout = currentActivity.findViewById(R.id.swiperefresh)
-            val linearLayout = currentActivity.findViewById<LinearLayout>(R.id.wrapperLayout)
-            val height = linearLayout.height - cv.height
-            refreshLayout.minimumHeight = height
-        }
-    }
+       if (resources.getBoolean(R.bool.two_pane)) {
+           refreshLayout = currentActivity.findViewById(R.id.swiperefresh)
+           val linearLayout = currentActivity.findViewById<LinearLayout>(R.id.wrapperLayout)
+           val height = linearLayout.height - cv.height
+           refreshLayout.minimumHeight = height
+       }
+   }
 
-    // Opens the product's detail page activity
-    private fun showProductDetailActivity(context: Context, operation: String, productEntity: Product?) {
-        productEntity?.let {
-          LOGGER.debug("within showProductDetailActivity for ${it.name}")
-          val isNavigationDisabled = (currentActivity as ProductsActivity).isNavigationDisabled
-          if (isNavigationDisabled) {
-              Toast.makeText(currentActivity, "Please save your changes first...", Toast.LENGTH_LONG).show()
-          } else {
-              adapter?.resetSelected()
-              adapter?.resetPreviouslyClicked()
-              viewModel.setSelectedEntity(it)
-              listener?.onFragmentStateChange(UIConstants.EVENT_ITEM_CLICKED, it)
-          }
-        }
-    }
+   // Opens the product's detail page activity
+   private fun showProductDetailActivity(context: Context, operation: String, productEntity: Product?) {
+       productEntity?.let {
+         LOGGER.debug("within showProductDetailActivity for ${it.name}")
+         val isNavigationDisabled = (currentActivity as ProductsActivity).isNavigationDisabled
+         if (isNavigationDisabled) {
+             Toast.makeText(currentActivity, "Please save your changes first...", Toast.LENGTH_LONG).show()
+         } else {
+             adapter?.resetSelected()
+             adapter?.resetPreviouslyClicked()
+             viewModel.setSelectedEntity(it)
+             listener?.onFragmentStateChange(UIConstants.EVENT_ITEM_CLICKED, it)
+         }
+       }
+   }
 
-    private class CollectionViewAdapter(activity: FragmentActivity, productList: List<Product>) : CollectionView.CollectionViewAdapter() {
-        private val products: List<Product>
-        private val currentActivity: FragmentActivity
+   private class CollectionViewAdapter(activity: FragmentActivity, productList: List<Product>) : CollectionView.CollectionViewAdapter() {
+       private val products: List<Product>
+       private val currentActivity: FragmentActivity
 
-        override fun onBindViewHolder(collectionViewItemHolder: CollectionViewItemHolder, i: Int) {
-            val cvi: CollectionViewItem = collectionViewItemHolder.collectionViewItem
-            val prod = products[i]
-            val productName = prod.name
-            cvi.apply {
-                detailImage = null
-                headline = productName
-                subheadline = prod.categoryName + ""
-                imageOutlineShape = AbstractEntityCell.IMAGE_SHAPE_OVAL
-                prod.pictureUrl?.let {
-                    val sapServiceManager = (currentActivity.application as SAPWizardApplication).sapServiceManager
-                    prepareDetailImageView().scaleType = ImageView.ScaleType.FIT_CENTER
-                    sapServiceManager?.let {sapServiceManager ->
-                        Glide.with(currentActivity.applicationContext)
-                                .load(EntityMediaResource.getMediaResourceUrl(prod, sapServiceManager.serviceRoot)) // Import com.bumptech.glide.Glide for RequestOptions()
-                                .apply(RequestOptions().fitCenter())
-                                .transition(DrawableTransitionOptions.withCrossFade())
-                                .into(prepareDetailImageView())
-                    }
-                } ?: run { // No picture is available, so use a character from the product string as the image thumbnail
-                    detailImageCharacter = productName.substring(0, 1)
-                    setDetailCharacterBackgroundTintList(com.sap.cloud.mobile.fiori.R.color.sap_ui_contact_placeholder_color_1)
-                }
-            }
-        }
+       override fun onBindViewHolder(collectionViewItemHolder: CollectionViewItemHolder, i: Int) {
+           val cvi: CollectionViewItem = collectionViewItemHolder.collectionViewItem
+           val prod = products[i]
+           val productName = prod.name
+           cvi.apply {
+               detailImage = null
+               headline = productName
+               subheadline = prod.categoryName + ""
+               imageOutlineShape = AbstractEntityCell.IMAGE_SHAPE_OVAL
+               prod.pictureUrl?.let {
+                   val sapServiceManager = (currentActivity.application as SAPWizardApplication).sapServiceManager
+                   prepareDetailImageView().scaleType = ImageView.ScaleType.FIT_CENTER
+                   sapServiceManager?.let {sapServiceManager ->
+                       Glide.with(currentActivity.applicationContext)
+                               .load(EntityMediaResource.getMediaResourceUrl(prod, sapServiceManager.serviceRoot)) // Import com.bumptech.glide.Glide for RequestOptions()
+                               .apply(RequestOptions().fitCenter())
+                               .transition(DrawableTransitionOptions.withCrossFade())
+                               .into(prepareDetailImageView())
+                   }
+               } ?: run { // No picture is available, so use a character from the product string as the image thumbnail
+                   detailImageCharacter = productName.substring(0, 1)
+                   setDetailCharacterBackgroundTintList(com.sap.cloud.mobile.fiori.R.color.sap_ui_contact_placeholder_color_1)
+               }
+           }
+       }
 
-        override fun getItemCount(): Int {
-            return products.size
-        }
+       override fun getItemCount(): Int {
+           return products.size
+       }
 
-        init {
-            products = productList
-            currentActivity = activity
-        }
-    }
-    ```
+       init {
+           products = productList
+           currentActivity = activity
+       }
+   }
+   ```
 
 13. On Windows, press **`Ctrl+F12`**, or on a Mac, press **`command+F12`**, and type **`prepareViewModel`**, to move to the `prepareViewModel` method.
 
 14. Replace the `ViewModelProvider(currentActivity).get(ProductViewModel::class.java)` line of the method with the following code:
 
-    ```Kotlin
-    ViewModelProvider(currentActivity).get(ProductViewModel::class.java).also {
-        it.initialRead{errorMessage ->
-            showError(errorMessage)
-        }
-        val cv: CollectionView = currentActivity.findViewById(R.id.collectionView)
-        createCollectionView(cv)
-    }
-    ```
+   ```Kotlin
+   ViewModelProvider(currentActivity).get(ProductViewModel::class.java).also {
+       it.initialRead{errorMessage ->
+           showError(errorMessage)
+       }
+       val cv: CollectionView = currentActivity.findViewById(R.id.collectionView)
+       createCollectionView(cv)
+   }
+   ```
 
 15. On Windows, press **`Ctrl+F12`**, or on a Mac, press **`command+F12`**, and type **`onCreate`**, to move to the `onCreate` method.
 
 16. Add the following lines of code at the end of the method:
 
-    ```Kotlin
-    // Query the SalesOrderItems and order by gross amount received from sales
-    // Change the orderBy arguments to SalesOrderItem.productID to rearrange the CollectionView order of products
-    val dq = DataQuery().orderBy(SalesOrderItem.productID)
-    // Get the DataService class, which we will use to query the back-end OData service
-    val espmContainer = sapServiceManager?.eSPMContainer
-    espmContainer?.let {
-        val httpHeaders: HttpHeaders = if (EntityMediaResource.isV4(it.metadata.versionCode) && EntityMediaResource.hasMediaResources(EntityTypes.salesOrderItem)) {
-            val header = HttpHeaders()
-            header.set("Accept", "application/json;odata.metadata=full")
-            header
-        } else HttpHeaders.empty
-        it.getSalesOrderItemsAsync(dq, { querySales: List<SalesOrderItem>? ->
-            LOGGER.debug("CollectionView: executed sales order query in onCreate")
-            querySales?.let { querysales ->
-                for (sale in querysales) {
-                    if (salesList.containsKey(sale.productID.toString())) {
-                        salesList[sale.productID.toString()] = salesList[sale.productID.toString()]!!.toInt() + sale.quantity
-                    } else {
-                        salesList[sale.productID.toString()] = sale.quantity
-                    }
-                    LOGGER.debug("CollectionView ${sale.productID} : ${sale.quantity} : ${sale.grossAmount}")
-                }
-                salesList = sortByValue(salesList)
-                LOGGER.debug("CollectionView: salesList size = ${salesList.size}")
-                queryProducts()
-            } ?: LOGGER.debug("CollectionView: sales query list is null")
-        }, { re: RuntimeException -> LOGGER.debug("CollectionView: An error occurred during async sales query: ${re.message}")
-        }, httpHeaders)
-    }
-    ```
+   ```Kotlin
+   // Query the SalesOrderItems and order by gross amount received from sales
+   // Change the orderBy arguments to SalesOrderItem.productID to rearrange the CollectionView order of products
+   val dq = DataQuery().orderBy(SalesOrderItem.productID)
+   // Get the DataService class, which we will use to query the back-end OData service
+   val espmContainer = sapServiceManager?.eSPMContainer
+   espmContainer?.let {
+       val httpHeaders: HttpHeaders = if (EntityMediaResource.isV4(it.metadata.versionCode) && EntityMediaResource.hasMediaResources(EntityTypes.salesOrderItem)) {
+           val header = HttpHeaders()
+           header.set("Accept", "application/json;odata.metadata=full")
+           header
+       } else HttpHeaders.empty
+       it.getSalesOrderItemsAsync(dq, { querySales: List<SalesOrderItem>? ->
+           LOGGER.debug("CollectionView: executed sales order query in onCreate")
+           querySales?.let { querysales ->
+               for (sale in querysales) {
+                   if (salesList.containsKey(sale.productID.toString())) {
+                       salesList[sale.productID.toString()] = salesList[sale.productID.toString()]!!.toInt() + sale.quantity
+                   } else {
+                       salesList[sale.productID.toString()] = sale.quantity
+                   }
+                   LOGGER.debug("CollectionView ${sale.productID} : ${sale.quantity} : ${sale.grossAmount}")
+               }
+               salesList = sortByValue(salesList)
+               LOGGER.debug("CollectionView: salesList size = ${salesList.size}")
+               queryProducts()
+           } ?: LOGGER.debug("CollectionView: sales query list is null")
+       }, { re: RuntimeException -> LOGGER.debug("CollectionView: An error occurred during async sales query: ${re.message}")
+       }, httpHeaders)
+   }
+   ```
 
 17. Run the app. You'll notice that the **Products** screen now has a component at the top of the screen that allows horizontal scrolling to view the top products. Tap a product to see more details. Alternatively, tap **SEE ALL** to see all the products.
 

--- a/tutorials/sdk-android-wizard-app-logging/sdk-android-wizard-app-logging.md
+++ b/tutorials/sdk-android-wizard-app-logging/sdk-android-wizard-app-logging.md
@@ -34,31 +34,31 @@ time: 15
 
     Note that the following code block contains two logger statements:
 
-    ```Kotlin
-    init {
-        //init from shared preference
-        viewModelScope.launch(Dispatchers.Default) {
-            preferencesFlow.collect { userReference ->
-                logger.debug("get preference as {}", userReference.logSetting)
-                _settingUIState.update { uiState ->
-                    uiState.copy(level = LogPolicy.getLogLevel(userReference.logSetting))
-                }
-            }
-        }
+   ```Kotlin
+   init {
+       //init from shared preference
+       viewModelScope.launch(Dispatchers.Default) {
+           preferencesFlow.collect { userReference ->
+               logger.debug("get preference as {}", userReference.logSetting)
+               _settingUIState.update { uiState ->
+                   uiState.copy(level = LogPolicy.getLogLevel(userReference.logSetting))
+               }
+           }
+       }
 
-        val consentUsage = UserSecureStoreDelegate.getInstance().consentStatus(ConsentType.USAGE)
-        val consentCrashReport =
-            UserSecureStoreDelegate.getInstance().consentStatus(ConsentType.CRASH_REPORT)
-        logger.debug(
-            "init consent data : consentUsage {}, consentCrashReport {}",
-            consentUsage,
-            consentCrashReport
-        )
+       val consentUsage = UserSecureStoreDelegate.getInstance().consentStatus(ConsentType.USAGE)
+       val consentCrashReport =
+           UserSecureStoreDelegate.getInstance().consentStatus(ConsentType.CRASH_REPORT)
+       logger.debug(
+           "init consent data : consentUsage {}, consentCrashReport {}",
+           consentUsage,
+           consentCrashReport
+       )
 
-        ... ...
-    ```
+       ... ...
+   ```
 
-    These messages will be logged when the app's log level is set to **Debug** or **Path** and the app's **Settings** menu item is opened.
+   These messages will be logged when the app's log level is set to **Debug** or **Path** and the app's **Settings** menu item is opened.
 
 [OPTION END]
 
@@ -70,20 +70,20 @@ time: 15
 
     Note that the following method contains two LOGGER statements:
 
-    ```Kotlin
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        LOGGER.debug("onOptionsItemSelected: " + item.title)
-        return when (item.itemId) {
-            R.id.menu_settings -> {
-                LOGGER.debug("settings screen menu item selected.")
-                Intent(this, SettingsActivity::class.java).also {
-                    this.startActivity(it)
-                }
-                true
-            }
-    ```
+   ```Kotlin
+   override fun onOptionsItemSelected(item: MenuItem): Boolean {
+       LOGGER.debug("onOptionsItemSelected: " + item.title)
+       return when (item.itemId) {
+           R.id.menu_settings -> {
+               LOGGER.debug("settings screen menu item selected.")
+               Intent(this, SettingsActivity::class.java).also {
+                   this.startActivity(it)
+               }
+               true
+           }
+   ```
 
-    These messages will be logged when the app's log level is set to **Debug** or **Path** and the app's **Settings** menu item is opened.
+   These messages will be logged when the app's log level is set to **Debug** or **Path** and the app's **Settings** menu item is opened.
 
 [OPTION END]
 

--- a/tutorials/sdk-android-wizard-app-map/sdk-android-wizard-app-map.md
+++ b/tutorials/sdk-android-wizard-app-map/sdk-android-wizard-app-map.md
@@ -36,61 +36,61 @@ In this section you will create a new activity to display a map.
 
 1. In Android Studio, in the `AndroidManifest.xml` file, add the following content as a child of the `<application>` tag right before `<activity>` tags:
 
-    ```XML
-    <!--
-        TODO: Before you run your application, you need a Google Maps API key.
+   ```XML
+   <!--
+       TODO: Before you run your application, you need a Google Maps API key.
 
-        To get one, follow the directions here:
+       To get one, follow the directions here:
 
-        https://developers.google.com/maps/documentation/android-sdk/get-api-key
+       https://developers.google.com/maps/documentation/android-sdk/get-api-key
 
-        Once you have your API key (it starts with "AIza"), define a new property in your
-        project's local.properties file (e.g. MAPS_API_KEY=Aiza...).
-    -->
-    <meta-data
-        android:name="com.google.android.geo.API_KEY"
-        android:value="${MAPS_API_KEY}" />
-    ```
+       Once you have your API key (it starts with "AIza"), define a new property in your
+       project's local.properties file (e.g. MAPS_API_KEY=Aiza...).
+   -->
+   <meta-data
+       android:name="com.google.android.geo.API_KEY"
+       android:value="${MAPS_API_KEY}" />
+   ```
 
 2. Follow the directions mentioned in the above comments to obtain an **API key**.
 
 3. Open the `local.properties` file in your project-level directory and then add the following code. Replace `YOUR_API_KEY` with your API key.
 
-    ```
-    MAPS_API_KEY=YOUR_API_KEY
-    ```
+   ```
+   MAPS_API_KEY=YOUR_API_KEY
+   ```
 
 4. In Android Studio, in the top-level `build.gradle` file, add the following code to the `dependencies` element under `buildscript`.
 
-    ```Gradle
-    buildscript {
-        dependencies {
-            // ...
-            classpath("com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1")
-        }
-    }
-    ```
+   ```Gradle
+   buildscript {
+       dependencies {
+           // ...
+           classpath("com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1")
+       }
+   }
+   ```
 
 5. Open the module-level `build.gradle` file and add the following code to the `plugins` element.
 
-    ```Gradle
-    plugins {
-        id("com.android.application")
-        // ...
-        id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
-    }
-    ```
+   ```Gradle
+   plugins {
+       id("com.android.application")
+       // ...
+       id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
+   }
+   ```
 
 6. Add the following dependency to the module-level `build.gradle` file and click **Sync Now** to sync the project:
 
-    ```Gradle
-    dependencies {
-        // Android Maps Compose composables for the Maps SDK for Android
-        implementation("com.google.maps.android:maps-compose:6.12.2")
+   ```Gradle
+   dependencies {
+       // Android Maps Compose composables for the Maps SDK for Android
+       implementation("com.google.maps.android:maps-compose:6.12.2")
 
-        ... ...
-    }
-    ```
+       ... ...
+   }
+   ```
 
 7. In the project explorer, navigate to **`app > kotlin+java > com.sap.wizapp > ui > odata > screens > customer`**.
 
@@ -100,46 +100,46 @@ In this section you will create a new activity to display a map.
 
 10. Replace the content of `CustomersMapScreen` with the following:
 
-    ```Kotlin
-    package com.sap.wizapp.ui.odata.screens.customer
+   ```Kotlin
+   package com.sap.wizapp.ui.odata.screens.customer
 
-    import androidx.compose.foundation.layout.fillMaxSize
-    import androidx.compose.runtime.Composable
-    import androidx.compose.ui.Modifier
-    import com.google.android.gms.maps.model.CameraPosition
-    import com.google.android.gms.maps.model.LatLng
-    import com.google.maps.android.compose.GoogleMap
-    import com.google.maps.android.compose.Marker
-    import com.google.maps.android.compose.rememberCameraPositionState
-    import com.google.maps.android.compose.rememberMarkerState
-    import com.sap.wizapp.ui.odata.viewmodel.ODataViewModel
+   import androidx.compose.foundation.layout.fillMaxSize
+   import androidx.compose.runtime.Composable
+   import androidx.compose.ui.Modifier
+   import com.google.android.gms.maps.model.CameraPosition
+   import com.google.android.gms.maps.model.LatLng
+   import com.google.maps.android.compose.GoogleMap
+   import com.google.maps.android.compose.Marker
+   import com.google.maps.android.compose.rememberCameraPositionState
+   import com.google.maps.android.compose.rememberMarkerState
+   import com.sap.wizapp.ui.odata.viewmodel.ODataViewModel
 
-    val CustomersMapScreen:
-            @Composable
-                (
-                navigateToHome: () -> Unit,
-                navigateUp: () -> Unit,
-                viewModel: ODataViewModel<EntityValue>,
-                isExpandScreen: Boolean,
-            ) -> Unit =
-        { _, _, _, _ ->
-            val sydney = LatLng(-33.865143, 151.209900)
-            val sydneyMarkerState = rememberMarkerState(position = sydney)
-            val cameraPositionState = rememberCameraPositionState {
-                position = CameraPosition.fromLatLngZoom(sydney, 1f)
-            }
-            GoogleMap(
-                modifier = Modifier.fillMaxSize(),
-                cameraPositionState = cameraPositionState
-            ) {
-                Marker(
-                    state = sydneyMarkerState,
-                    title = "Sydney",
-                    snippet = "Marker in Sydney"
-                )
-            }
-        }
-    ```
+   val CustomersMapScreen:
+           @Composable
+               (
+               navigateToHome: () -> Unit,
+               navigateUp: () -> Unit,
+               viewModel: ODataViewModel<EntityValue>,
+               isExpandScreen: Boolean,
+           ) -> Unit =
+       { _, _, _, _ ->
+           val sydney = LatLng(-33.865143, 151.209900)
+           val sydneyMarkerState = rememberMarkerState(position = sydney)
+           val cameraPositionState = rememberCameraPositionState {
+               position = CameraPosition.fromLatLngZoom(sydney, 1f)
+           }
+           GoogleMap(
+               modifier = Modifier.fillMaxSize(),
+               cameraPositionState = cameraPositionState
+           ) {
+               Marker(
+                   state = sydneyMarkerState,
+                   title = "Sydney",
+                   snippet = "Marker in Sydney"
+               )
+           }
+       }
+   ```
 
 11. On Windows, press **`Ctrl+Shift+N`**, or, on a Mac, press **`command+shift+O`**, and type **`ODataCommonUI`** to open `ODataCommonUI.kt`.
 
@@ -163,56 +163,56 @@ In this section you will create a new activity to display a map.
 
 1. In Android Studio, in the `AndroidManifest.xml` file, add the following content as a child of the `<application>` tag right before `<activity>` tags:
 
-    ```XML
-    <!--
-            TODO: Before you run your application, you need a Google Maps API key.
+   ```XML
+   <!--
+           TODO: Before you run your application, you need a Google Maps API key.
 
-            To get one, follow the directions here:
+           To get one, follow the directions here:
 
-            https://developers.google.com/maps/documentation/android-sdk/get-api-key
+           https://developers.google.com/maps/documentation/android-sdk/get-api-key
 
-            Once you have your API key (it starts with "AIza"), define a new property in your
-            project's local.properties file (e.g. MAPS_API_KEY=Aiza...).
-    -->
-    <meta-data
-        android:name="com.google.android.geo.API_KEY"
-        android:value="${MAPS_API_KEY}" />
-    ```
+           Once you have your API key (it starts with "AIza"), define a new property in your
+           project's local.properties file (e.g. MAPS_API_KEY=Aiza...).
+   -->
+   <meta-data
+       android:name="com.google.android.geo.API_KEY"
+       android:value="${MAPS_API_KEY}" />
+   ```
 
 2. Follow the directions mentioned in the above comments to obtain an **API key**.
 
 3. Open the `local.properties` file in your project-level directory and then add the following code. Replace `YOUR_API_KEY` with your API key.
 
-    ```
-    MAPS_API_KEY=YOUR_API_KEY
-    ```
+   ```
+   MAPS_API_KEY=YOUR_API_KEY
+   ```
 
 4. In Android Studio, in the top-level `build.gradle` file, add the following code to the `dependencies` element under `buildscript`.
 
-    ```Gradle
-    buildscript {
-        dependencies {
-            // ...
-            classpath("com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1")
-        }
-    }
-    ```
+   ```Gradle
+   buildscript {
+       dependencies {
+           // ...
+           classpath("com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1")
+       }
+   }
+   ```
 
 5. Open the module-level `build.gradle` file and add the following code to the top of the file.
 
-    ```Gradle
-    apply plugin: 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
-    ```
+   ```Gradle
+   apply plugin: 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
+   ```
 
 6. Add the following dependency to the module-level `build.gradle` file and click **Sync Now** to sync the project:
 
-    ```Gradle
-    dependencies {
-        implementation 'com.google.android.gms:play-services-maps:19.2.0'
+   ```Gradle
+   dependencies {
+       implementation 'com.google.android.gms:play-services-maps:19.2.0'
 
-        ... ...
-    }
-    ```
+       ... ...
+   }
+   ```
 
 7. In the project explorer, navigate to **`app > kotlin+java > com.sap.wizapp > mdui > customers`**.
 
@@ -222,73 +222,73 @@ In this section you will create a new activity to display a map.
 
 10. Replace the class content with the following:
 
-    ```Kotlin
-    package com.sap.wizapp.mdui.customers
+   ```Kotlin
+   package com.sap.wizapp.mdui.customers
 
-    import androidx.appcompat.app.AppCompatActivity
-    import android.os.Bundle
-    import com.sap.wizapp.R
+   import androidx.appcompat.app.AppCompatActivity
+   import android.os.Bundle
+   import com.sap.wizapp.R
 
-    import com.google.android.gms.maps.CameraUpdateFactory
-    import com.google.android.gms.maps.GoogleMap
-    import com.google.android.gms.maps.OnMapReadyCallback
-    import com.google.android.gms.maps.SupportMapFragment
-    import com.google.android.gms.maps.model.LatLng
-    import com.google.android.gms.maps.model.MarkerOptions
-    import com.sap.wizapp.databinding.ActivityCustomersMapBinding
+   import com.google.android.gms.maps.CameraUpdateFactory
+   import com.google.android.gms.maps.GoogleMap
+   import com.google.android.gms.maps.OnMapReadyCallback
+   import com.google.android.gms.maps.SupportMapFragment
+   import com.google.android.gms.maps.model.LatLng
+   import com.google.android.gms.maps.model.MarkerOptions
+   import com.sap.wizapp.databinding.ActivityCustomersMapBinding
 
-    class CustomersMapActivity : AppCompatActivity(), OnMapReadyCallback {
+   class CustomersMapActivity : AppCompatActivity(), OnMapReadyCallback {
 
-        private lateinit var mMap: GoogleMap
-        private lateinit var binding: ActivityCustomersMapBinding
+       private lateinit var mMap: GoogleMap
+       private lateinit var binding: ActivityCustomersMapBinding
 
-        override fun onCreate(savedInstanceState: Bundle?) {
-            super.onCreate(savedInstanceState)
+       override fun onCreate(savedInstanceState: Bundle?) {
+           super.onCreate(savedInstanceState)
 
-            binding = ActivityCustomersMapBinding.inflate(layoutInflater)
-            setContentView(binding.root)
+           binding = ActivityCustomersMapBinding.inflate(layoutInflater)
+           setContentView(binding.root)
 
-            // Obtain the SupportMapFragment and get notified when the map is ready to be used.
-            val mapFragment = supportFragmentManager
-                .findFragmentById(R.id.map) as SupportMapFragment
-            mapFragment.getMapAsync(this)
-        }
+           // Obtain the SupportMapFragment and get notified when the map is ready to be used.
+           val mapFragment = supportFragmentManager
+               .findFragmentById(R.id.map) as SupportMapFragment
+           mapFragment.getMapAsync(this)
+       }
 
-        /**
-        * Manipulates the map once available.
-        * This callback is triggered when the map is ready to be used.
-        * This is where we can add markers or lines, add listeners or move the camera. In this case,
-        * we just add a marker near Sydney, Australia.
-        * If Google Play services is not installed on the device, the user will be prompted to install
-        * it inside the SupportMapFragment. This method will only be triggered once the user has
-        * installed Google Play services and returned to the app.
-        */
-        override fun onMapReady(googleMap: GoogleMap) {
-            mMap = googleMap
+       /**
+       * Manipulates the map once available.
+       * This callback is triggered when the map is ready to be used.
+       * This is where we can add markers or lines, add listeners or move the camera. In this case,
+       * we just add a marker near Sydney, Australia.
+       * If Google Play services is not installed on the device, the user will be prompted to install
+       * it inside the SupportMapFragment. This method will only be triggered once the user has
+       * installed Google Play services and returned to the app.
+       */
+       override fun onMapReady(googleMap: GoogleMap) {
+           mMap = googleMap
 
-            // Add a marker in Sydney and move the camera
-            val sydney = LatLng(-34.0, 151.0)
-            mMap.addMarker(MarkerOptions().position(sydney).title("Marker in Sydney"))
-            mMap.moveCamera(CameraUpdateFactory.newLatLng(sydney))
-        }
-    }
-    ```
+           // Add a marker in Sydney and move the camera
+           val sydney = LatLng(-34.0, 151.0)
+           mMap.addMarker(MarkerOptions().position(sydney).title("Marker in Sydney"))
+           mMap.moveCamera(CameraUpdateFactory.newLatLng(sydney))
+       }
+   }
+   ```
 
 11. On Windows, press **`Ctrl+Shift+N`**, or, on a Mac, press **`command+shift+O`**, and type **`activity_customers_map`** to open `activity_customers_map.xml`.
 
 12. Replace its contents with the following:
 
-    ```XML
-    <?xml version="1.0" encoding="utf-8"?>
-    <fragment xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:map="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:id="@+id/map"
-        android:name="com.google.android.gms.maps.SupportMapFragment"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:context=".mdui.customers.CustomersMapActivity" />
-    ```
+   ```XML
+   <?xml version="1.0" encoding="utf-8"?>
+   <fragment xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:map="http://schemas.android.com/apk/res-auto"
+       xmlns:tools="http://schemas.android.com/tools"
+       android:id="@+id/map"
+       android:name="com.google.android.gms.maps.SupportMapFragment"
+       android:layout_width="match_parent"
+       android:layout_height="match_parent"
+       tools:context=".mdui.customers.CustomersMapActivity" />
+   ```
 
 13. On Windows, press **`Ctrl+N`**, or, on a Mac, press **`command+O`**, and type **`EntitySetListActivity`** to open `EntitySetListActivity.kt`.
 
@@ -320,101 +320,101 @@ In this section, you will add code to place a marker on the map for each custome
 
 2. Add the following variables:
 
-    ```Kotlin
-    private val locations = HashMap<String, LatLng>()
-    private var customerList = mutableListOf<Customer>()
-    ```
+   ```Kotlin
+   private val locations = HashMap<String, LatLng>()
+   private var customerList = mutableListOf<Customer>()
+   ```
 
 3. Add the following method:
 
-    ```Kotlin
-    private suspend fun getCustomerList() {
-        val query = DataQuery()
-            .from(ESPMContainerMetadata.EntitySets.customers)
-            .where(
-                Customer.country.equal("US")
-                    .or(Customer.country.equal("CA"))
-                    .or(Customer.country.equal("MX")))
-        val eSPMContainer = SAPServiceManager.eSPMContainer
-        eSPMContainer?.getCustomers(query)?.also {
-            customerList = it
-        }
-    }
+   ```Kotlin
+   private suspend fun getCustomerList() {
+       val query = DataQuery()
+           .from(ESPMContainerMetadata.EntitySets.customers)
+           .where(
+               Customer.country.equal("US")
+                   .or(Customer.country.equal("CA"))
+                   .or(Customer.country.equal("MX")))
+       val eSPMContainer = SAPServiceManager.eSPMContainer
+       eSPMContainer?.getCustomers(query)?.also {
+           customerList = it
+       }
+   }
 
-    private fun getCustomerLatLongFromAddress(address: String, context: Context): LatLng? {
-        locations[address]?.let {
-            return it
-        }
-        
-        val coder = Geocoder(context)
-        try {   // May throw an IOException
-            val addresses = coder.getFromLocationName(address, 5)
-            if (addresses.isNullOrEmpty()) {
-                return null
-            }
-            val location = addresses[0]
-            return LatLng(location.latitude, location.longitude)
-        } catch (ex: IOException) {
-            ex.printStackTrace()
-            return null
-        }
-    }
-    ```
+   private fun getCustomerLatLongFromAddress(address: String, context: Context): LatLng? {
+       locations[address]?.let {
+           return it
+       }
+       
+       val coder = Geocoder(context)
+       try {   // May throw an IOException
+           val addresses = coder.getFromLocationName(address, 5)
+           if (addresses.isNullOrEmpty()) {
+               return null
+           }
+           val location = addresses[0]
+           return LatLng(location.latitude, location.longitude)
+       } catch (ex: IOException) {
+           ex.printStackTrace()
+           return null
+       }
+   }
+   ```
 
 4. Replace the variable `CustomersMapScreen` with the following:
 
-    ```Kotlin
-    val CustomersMapScreen:
-        @Composable
-            (
-            navigateToHome: () -> Unit,
-            navigateUp: () -> Unit,
-            viewModel: ODataViewModel<EntityValue>,
-            isExpandScreen: Boolean,
-        ) -> Unit =
-    { _, _, viewModel, _ ->
-        val centre = LatLng(39.8283, -98.5795)
-        val cameraPositionState = rememberCameraPositionState {
-            position = CameraPosition.fromLatLngZoom(centre, 1f)
-        }
+   ```Kotlin
+   val CustomersMapScreen:
+       @Composable
+           (
+           navigateToHome: () -> Unit,
+           navigateUp: () -> Unit,
+           viewModel: ODataViewModel<EntityValue>,
+           isExpandScreen: Boolean,
+       ) -> Unit =
+   { _, _, viewModel, _ ->
+       val centre = LatLng(39.8283, -98.5795)
+       val cameraPositionState = rememberCameraPositionState {
+           position = CameraPosition.fromLatLngZoom(centre, 1f)
+       }
 
-        // For demo purposes, speed up the lookup of address details.
-        // Will use Geocoder to translate an address to a LatLng if address is not in this list
-        locations["Wilmington, Delaware, US"] = LatLng(39.744655, -75.5483909)
-        locations["Antioch, Illinois, US"] = LatLng(42.4772418, -88.0956396)
-        locations["Santa Clara, California, US"] = LatLng(37.354107899999995, -121.9552356)
-        locations["Hermosillo, MX"] = LatLng(29.0729673, -110.9559192)
-        locations["Bismarck, North Dakota, US"] = LatLng(46.808326799999996, -100.7837392)
-        locations["Ottawa, CA"] = LatLng(45.4215296, -75.69719309999999)
-        locations["México, MX"] = LatLng(23.634501, -102.55278399999999)
-        locations["Boca Raton, Florida, US"] = LatLng(26.368306399999998, -80.1289321)
-        locations["Carrollton, Texas, US"] = LatLng(32.9756415, -96.8899636)
-        locations["Lombard, Illinois, US"] = LatLng(41.8800296, -88.00784349999999)
-        locations["Moorestown, US"] = LatLng(39.9688817, -74.948886)
+       // For demo purposes, speed up the lookup of address details.
+       // Will use Geocoder to translate an address to a LatLng if address is not in this list
+       locations["Wilmington, Delaware, US"] = LatLng(39.744655, -75.5483909)
+       locations["Antioch, Illinois, US"] = LatLng(42.4772418, -88.0956396)
+       locations["Santa Clara, California, US"] = LatLng(37.354107899999995, -121.9552356)
+       locations["Hermosillo, MX"] = LatLng(29.0729673, -110.9559192)
+       locations["Bismarck, North Dakota, US"] = LatLng(46.808326799999996, -100.7837392)
+       locations["Ottawa, CA"] = LatLng(45.4215296, -75.69719309999999)
+       locations["México, MX"] = LatLng(23.634501, -102.55278399999999)
+       locations["Boca Raton, Florida, US"] = LatLng(26.368306399999998, -80.1289321)
+       locations["Carrollton, Texas, US"] = LatLng(32.9756415, -96.8899636)
+       locations["Lombard, Illinois, US"] = LatLng(41.8800296, -88.00784349999999)
+       locations["Moorestown, US"] = LatLng(39.9688817, -74.948886)
 
-        runBlocking {
-            getCustomerList()
-        }
+       runBlocking {
+           getCustomerList()
+       }
 
-        GoogleMap(
-            modifier = Modifier.fillMaxSize(),
-            cameraPositionState = cameraPositionState
-        ) {
-            customerList.forEach { customer ->
-                Log.d("", "Adding a marker for " + customer.city)
-                val latLng = getCustomerLatLongFromAddress(customer.city + ", " + customer.country, viewModel.getApplication())
-                latLng?.let {
-                    val markerState = rememberMarkerState(position = it)
-                    Marker(
-                        state = markerState,
-                        title = customer.firstName + " " + customer.lastName,
-                        tag = customer
-                    )
-                }
-            }
-        }
-    }
-    ```
+       GoogleMap(
+           modifier = Modifier.fillMaxSize(),
+           cameraPositionState = cameraPositionState
+       ) {
+           customerList.forEach { customer ->
+               Log.d("", "Adding a marker for " + customer.city)
+               val latLng = getCustomerLatLongFromAddress(customer.city + ", " + customer.country, viewModel.getApplication())
+               latLng?.let {
+                   val markerState = rememberMarkerState(position = it)
+                   Marker(
+                       state = markerState,
+                       title = customer.firstName + " " + customer.lastName,
+                       tag = customer
+                   )
+               }
+           }
+       }
+   }
+   ```
 
 5. Run the app.
 
@@ -434,92 +434,92 @@ In this section, you will add code to place a marker on the map for each custome
 
 2. Add the following class variable:
 
-    ```Kotlin
-    private val locations = HashMap<String, LatLng>()
-    ```
+   ```Kotlin
+   private val locations = HashMap<String, LatLng>()
+   ```
 
 3. Add the following methods:
 
-    ```Kotlin
-    private fun addCustomersToMap() {
-        val query = DataQuery()
-                .from(ESPMContainerMetadata.EntitySets.customers)
-                .where(Customer.country.equal("US")
-                        .or(Customer.country.equal("CA"))
-                        .or(Customer.country.equal("MX")))
-        val sapServiceManager = (application as SAPWizardApplication).sapServiceManager
-        val eSPMContainer = sapServiceManager?.eSPMContainer
-        eSPMContainer?.let {
-            it.getCustomersAsync(query, { customers: List<Customer> ->
-                for (customer in customers) {
-                    Log.d("", "Adding a marker for " + customer.city)
-                    addCustomerMarkerToMap(customer)
-                }
-            }, { re: RuntimeException -> Log.d("", "An error occurred during async query: " + re.message) })
-        }
-    }
+   ```Kotlin
+   private fun addCustomersToMap() {
+       val query = DataQuery()
+               .from(ESPMContainerMetadata.EntitySets.customers)
+               .where(Customer.country.equal("US")
+                       .or(Customer.country.equal("CA"))
+                       .or(Customer.country.equal("MX")))
+       val sapServiceManager = (application as SAPWizardApplication).sapServiceManager
+       val eSPMContainer = sapServiceManager?.eSPMContainer
+       eSPMContainer?.let {
+           it.getCustomersAsync(query, { customers: List<Customer> ->
+               for (customer in customers) {
+                   Log.d("", "Adding a marker for " + customer.city)
+                   addCustomerMarkerToMap(customer)
+               }
+           }, { re: RuntimeException -> Log.d("", "An error occurred during async query: " + re.message) })
+       }
+   }
 
-    private fun getCustomerLatLongFromAddress(address: String): LatLng? {
-        locations[address]?.let {
-            return it
-        }
+   private fun getCustomerLatLongFromAddress(address: String): LatLng? {
+       locations[address]?.let {
+           return it
+       }
 
-        val coder = Geocoder(this)
-        try
-        {   // May throw an IOException
-            val addresses = coder.getFromLocationName(address, 5)
-            if (addresses.isNullOrEmpty())
-            {
-                return null
-            }
-            val location = addresses[0]
-            return LatLng(location.latitude, location.longitude)
-        }
-        catch (ex: IOException) {
-            ex.printStackTrace()
-            return null
-        }
-    }
+       val coder = Geocoder(this)
+       try
+       {   // May throw an IOException
+           val addresses = coder.getFromLocationName(address, 5)
+           if (addresses.isNullOrEmpty())
+           {
+               return null
+           }
+           val location = addresses[0]
+           return LatLng(location.latitude, location.longitude)
+       }
+       catch (ex: IOException) {
+           ex.printStackTrace()
+           return null
+       }
+   }
 
-    private fun addCustomerMarkerToMap(customer: Customer) {
-        val latLng = getCustomerLatLongFromAddress(customer.city + ", " + customer.country)
-        latLng?.let {
-            val customerMarker = mMap.addMarker(MarkerOptions()
-                    //.snippet("")
-                    .position(it)
-                    .title(customer.firstName + " " + customer.lastName)
-            )
-            customerMarker?.tag = customer
-        }
-    }
-    ```
+   private fun addCustomerMarkerToMap(customer: Customer) {
+       val latLng = getCustomerLatLongFromAddress(customer.city + ", " + customer.country)
+       latLng?.let {
+           val customerMarker = mMap.addMarker(MarkerOptions()
+                   //.snippet("")
+                   .position(it)
+                   .title(customer.firstName + " " + customer.lastName)
+           )
+           customerMarker?.tag = customer
+       }
+   }
+   ```
 
 4. On Windows, press **`Ctrl+F12`**, or, on a Mac, press **`command+F12`**, and type **`onMapReady`** to move to the `onMapReady` method.
 
 5. Replace it with the following code:
 
-    ```Kotlin
-    override fun onMapReady(googleMap: GoogleMap) {
-        mMap = googleMap
-        val centre = LatLng(39.8283, -98.5795)
-        mMap.moveCamera(CameraUpdateFactory.newLatLng(centre))
+   ```Kotlin
+   override fun onMapReady(googleMap: GoogleMap) {
+       mMap = googleMap
+       val centre = LatLng(39.8283, -98.5795)
+       mMap.moveCamera(CameraUpdateFactory.newLatLng(centre))
 
-        // For demo purposes, speed up the lookup of address details.
-        // Will use Geocoder to translate an address to a LatLng if address is not in this list
-        locations.put("Wilmington, Delaware, US", LatLng(39.744655, -75.5483909))
-        locations.put("Antioch, Illinois, US", LatLng(42.4772418, -88.0956396))
-        locations.put("Santa Clara, California, US", LatLng(37.354107899999995, -121.9552356))
-        locations.put("Hermosillo, MX", LatLng(29.0729673, -110.9559192))
-        locations.put("Bismarck, North Dakota, US", LatLng(46.808326799999996, -100.7837392))
-        locations.put("Ottawa, CA", LatLng(45.4215296, -75.69719309999999))
-        locations.put("México, MX", LatLng(23.634501, -102.55278399999999))
-        locations.put("Boca Raton, Florida, US", LatLng(26.368306399999998, -80.1289321))
-        locations.put("Carrollton, Texas, US", LatLng(32.9756415, -96.8899636))
-        locations.put("Lombard, Illinois, US", LatLng(41.8800296, -88.00784349999999))
-        locations.put("Moorestown, US", LatLng(39.9688817, -74.948886))
-        addCustomersToMap()
-    }
-    ```
+       // For demo purposes, speed up the lookup of address details.
+       // Will use Geocoder to translate an address to a LatLng if address is not in this list
+       locations.put("Wilmington, Delaware, US", LatLng(39.744655, -75.5483909))
+       locations.put("Antioch, Illinois, US", LatLng(42.4772418, -88.0956396))
+       locations.put("Santa Clara, California, US", LatLng(37.354107899999995, -121.9552356))
+       locations.put("Hermosillo, MX", LatLng(29.0729673, -110.9559192))
+       locations.put("Bismarck, North Dakota, US", LatLng(46.808326799999996, -100.7837392))
+       locations.put("Ottawa, CA", LatLng(45.4215296, -75.69719309999999))
+       locations.put("México, MX", LatLng(23.634501, -102.55278399999999))
+       locations.put("Boca Raton, Florida, US", LatLng(26.368306399999998, -80.1289321))
+       locations.put("Carrollton, Texas, US", LatLng(32.9756415, -96.8899636))
+       locations.put("Lombard, Illinois, US", LatLng(41.8800296, -88.00784349999999))
+       locations.put("Moorestown, US", LatLng(39.9688817, -74.948886))
+       addCustomersToMap()
+   }
+   ```
 
 6. Run the app.
 
@@ -543,24 +543,24 @@ In this section, you will add code to display the customer detail screen when th
 
 1. In the `CustomersMapScreen.kt` file, add a parameter `onInfoWindowClick` to `Marker` which is located in `GoogleMap` of the variable `CustomersMapScreen` with the following code:
 
-    ```Kotlin
-    onInfoWindowClick = {
-        viewModel.onClickAction(customer)
-    }
-    ```
+   ```Kotlin
+   onInfoWindowClick = {
+       viewModel.onClickAction(customer)
+   }
+   ```
 
     Then `Marker` will look like below:
 
-    ```Kotlin
-    Marker(
-        state = markerState,
-        title = customer.firstName + " " + customer.lastName,
-        tag = customer,
-        onInfoWindowClick = {
-            viewModel.onClickAction(customer)
-        }
-    )
-    ```
+   ```Kotlin
+   Marker(
+       state = markerState,
+       title = customer.firstName + " " + customer.lastName,
+       tag = customer,
+       onInfoWindowClick = {
+           viewModel.onClickAction(customer)
+       }
+   )
+   ```
 
 2. Run the app. Select **Customers**, and tap on a marker. Then tap on the info marker.
 
@@ -576,26 +576,26 @@ In this section, you will add code to display the customer detail screen when th
 
 1. In the class definition for `CustomersMapActivity`, after `OnMapReadyCallback`, add:
 
-    ```Kotlin
-    , GoogleMap.OnInfoWindowClickListener
-    ```
+   ```Kotlin
+   , GoogleMap.OnInfoWindowClickListener
+   ```
 
 2. Add the following method to the class:
 
-    ```Kotlin
-    override fun onInfoWindowClick(marker: Marker) {//import com.google.android.gms.maps.model.Marker
-        val customer = marker.tag as Customer
-        val intent = Intent(this, CustomersActivity::class.java)
-        intent.putExtra(BundleKeys.ENTITY_INSTANCE, customer)
-        startActivity(intent)
-    }
-    ```
+   ```Kotlin
+   override fun onInfoWindowClick(marker: Marker) {//import com.google.android.gms.maps.model.Marker
+       val customer = marker.tag as Customer
+       val intent = Intent(this, CustomersActivity::class.java)
+       intent.putExtra(BundleKeys.ENTITY_INSTANCE, customer)
+       startActivity(intent)
+   }
+   ```
 
 3. In the `onMapReady` method in `CustomersMapActivity`, add the following line to the end of the method:
 
-    ```Kotlin
-    mMap.setOnInfoWindowClickListener(this)
-    ```
+   ```Kotlin
+   mMap.setOnInfoWindowClickListener(this)
+   ```
 
 4. On Windows, press **`Ctrl+N`**, or, on a Mac, press **`command+O`**, and type **`CustomersActivity`** to open `CustomersActivity.kt`.
 
@@ -603,51 +603,51 @@ In this section, you will add code to display the customer detail screen when th
 
 6. Replace the `if (savedInstanceState == null)` block (keep `else-block` unchanged) in the `onCreate` method with the following code:
 
-    ```Kotlin
-    if (savedInstanceState == null) {
-        val listFragment = CustomersListFragment()
-        intent.extras?.let {
-            if (it.containsKey(BundleKeys.ENTITY_INSTANCE)) {
-                listFragment.arguments = it
-            }
-        }
-        supportFragmentManager.beginTransaction()
-                .replace(R.id.masterFrame, listFragment, UIConstants.LIST_FRAGMENT_TAG)
-                .commit()
-    }
-    ```
+   ```Kotlin
+   if (savedInstanceState == null) {
+       val listFragment = CustomersListFragment()
+       intent.extras?.let {
+           if (it.containsKey(BundleKeys.ENTITY_INSTANCE)) {
+               listFragment.arguments = it
+           }
+       }
+       supportFragmentManager.beginTransaction()
+               .replace(R.id.masterFrame, listFragment, UIConstants.LIST_FRAGMENT_TAG)
+               .commit()
+   }
+   ```
 
 7. On Windows, press **`Ctrl+N`**, or, on a Mac, press **`command+O`**, and type **`CustomersListFragment`** to open `CustomersListFragment.kt`.
 
 8. Add the following variable to the top of the class:
 
-    ```Kotlin
-    private var entityFromMap: Customer? = null
-    ```
+   ```Kotlin
+   private var entityFromMap: Customer? = null
+   ```
 
 9. On Windows, press **`Ctrl+F12`**, or, on a Mac, press **`command+F12`**, and type **`onCreate`** to navigate to the `onCreate` method.
 
 10. Add the following code to the end of the method:
 
-    ```Kotlin
-    arguments?.let {
-        if (it.containsKey(BundleKeys.ENTITY_INSTANCE)) {
-            entityFromMap = it.get(BundleKeys.ENTITY_INSTANCE) as Customer
-        }
-    }
-    ```
+   ```Kotlin
+   arguments?.let {
+       if (it.containsKey(BundleKeys.ENTITY_INSTANCE)) {
+           entityFromMap = it.get(BundleKeys.ENTITY_INSTANCE) as Customer
+       }
+   }
+   ```
 
 11. On Windows, press **`Ctrl+F12`**, or, on a Mac, press **`command+F12`**, and type **`onViewStateRestored`** to navigate to the `onViewStateRestored` method.
 
 12. Add the following code to the end of the method:
 
-    ```Kotlin
-    entityFromMap?.let {
-        viewModel.setSelectedEntity(it)
-        listener?.onFragmentStateChange(UIConstants.EVENT_ITEM_CLICKED, it)
-        entityFromMap = null
-    }
-    ```
+   ```Kotlin
+   entityFromMap?.let {
+       viewModel.setSelectedEntity(it)
+       listener?.onFragmentStateChange(UIConstants.EVENT_ITEM_CLICKED, it)
+       entityFromMap = null
+   }
+   ```
 
 13. Run the app. Select **Customers**, and tap on a marker. Then tap on the info marker.
 
@@ -671,32 +671,32 @@ In this section, you will create a new activity that uses the Fiori Map control.
 
 2. Add the following code right after `AppTheme` and before `AppTheme.NoActionBar`:
 
-    ```XML
-    <style name="FioriMap.NoActionBar" parent="Theme.Fiori.Horizon.NoActionBar">
-        <item name="colorPrimary">?attr/sap_fiori_color_s2</item>
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
-        <item name="windowActionModeOverlay">true</item>
-    </style>
-    ```
+   ```XML
+   <style name="FioriMap.NoActionBar" parent="Theme.Fiori.Horizon.NoActionBar">
+       <item name="colorPrimary">?attr/sap_fiori_color_s2</item>
+       <item name="windowActionBar">false</item>
+       <item name="windowNoTitle">true</item>
+       <item name="windowActionModeOverlay">true</item>
+   </style>
+   ```
 
 3. On Windows, press **`Ctrl+Shift+N`**, or on a Mac, press **`command+shift+O`**, and type **`libs.versions.toml`** to open `libs.versions.toml`. 
 
 4. Add the following content right before `sap-cloud-foundation`:
 
-    ```Gradle
-    google-maps = { group = "com.sap.cloud.android", name = "google-maps", version.ref = "sapSdkVersion" }
-    ```
+   ```Gradle
+   google-maps = { group = "com.sap.cloud.android", name = "google-maps", version.ref = "sapSdkVersion" }
+   ```
 
 5. Add the following dependencies in the app module's `build.gradle` file to the `dependencies` element and click **Sync Now**.
 
-    ```Gradle
-    implementation("androidx.appcompat:appcompat:1.7.1")
-    implementation("com.google.android.material:material:1.13.0")
-    implementation("androidx.activity:activity-ktx:1.12.1")
-    implementation("androidx.constraintlayout:constraintlayout:2.2.1")
-    implementation(libs.google.maps)
-    ```
+   ```Gradle
+   implementation("androidx.appcompat:appcompat:1.7.1")
+   implementation("com.google.android.material:material:1.13.0")
+   implementation("androidx.activity:activity-ktx:1.12.1")
+   implementation("androidx.constraintlayout:constraintlayout:2.2.1")
+   implementation(libs.google.maps)
+   ```
 
 6. In Android Studio, using the project explorer, navigate to **`app > kotlin+java > com.sap.wizapp > ui`**.
 
@@ -708,328 +708,328 @@ In this section, you will create a new activity that uses the Fiori Map control.
 
 10. Replace the file contents in the newly created `CustomersFioriMapActivity.kt` with the following code:
 
-    ```Kotlin
-    package com.sap.wizapp.ui
+   ```Kotlin
+   package com.sap.wizapp.ui
 
-    import android.app.SearchManager
-    import android.content.Context
-    import android.location.Geocoder
-    import android.os.Bundle
-    import android.view.LayoutInflater
-    import android.view.inputmethod.InputMethodManager
-    import android.widget.ArrayAdapter
-    import android.widget.ImageButton
-    import androidx.appcompat.app.AppCompatActivity
-    import com.google.android.gms.maps.CameraUpdateFactory
-    import com.google.android.gms.maps.GoogleMap
-    import com.google.android.gms.maps.model.LatLng
-    import com.sap.cloud.android.odata.espmcontainer.Customer
-    import com.sap.cloud.android.odata.espmcontainer.ESPMContainerMetadata
-    import com.sap.cloud.mobile.fiori.maps.FioriMapSearchView
-    import com.sap.cloud.mobile.fiori.maps.FioriMarkerOptions
-    import com.sap.cloud.mobile.fiori.maps.FioriPoint
-    import com.sap.cloud.mobile.fiori.maps.LegendButton
-    import com.sap.cloud.mobile.fiori.maps.LocationButton
-    import com.sap.cloud.mobile.fiori.maps.SettingsButton
-    import com.sap.cloud.mobile.fiori.maps.ZoomExtentButton
-    import com.sap.cloud.mobile.fiori.maps.google.GoogleFioriMapView
-    import com.sap.cloud.mobile.fiori.maps.google.GoogleMapActionProvider
-    import com.sap.cloud.mobile.fiori.maps.google.GoogleMapViewModel
-    import com.sap.cloud.mobile.kotlin.odata.DataQuery
-    import com.sap.wizapp.R
-    import com.sap.wizapp.service.SAPServiceManager
-    import kotlinx.coroutines.runBlocking
-    import java.io.IOException
+   import android.app.SearchManager
+   import android.content.Context
+   import android.location.Geocoder
+   import android.os.Bundle
+   import android.view.LayoutInflater
+   import android.view.inputmethod.InputMethodManager
+   import android.widget.ArrayAdapter
+   import android.widget.ImageButton
+   import androidx.appcompat.app.AppCompatActivity
+   import com.google.android.gms.maps.CameraUpdateFactory
+   import com.google.android.gms.maps.GoogleMap
+   import com.google.android.gms.maps.model.LatLng
+   import com.sap.cloud.android.odata.espmcontainer.Customer
+   import com.sap.cloud.android.odata.espmcontainer.ESPMContainerMetadata
+   import com.sap.cloud.mobile.fiori.maps.FioriMapSearchView
+   import com.sap.cloud.mobile.fiori.maps.FioriMarkerOptions
+   import com.sap.cloud.mobile.fiori.maps.FioriPoint
+   import com.sap.cloud.mobile.fiori.maps.LegendButton
+   import com.sap.cloud.mobile.fiori.maps.LocationButton
+   import com.sap.cloud.mobile.fiori.maps.SettingsButton
+   import com.sap.cloud.mobile.fiori.maps.ZoomExtentButton
+   import com.sap.cloud.mobile.fiori.maps.google.GoogleFioriMapView
+   import com.sap.cloud.mobile.fiori.maps.google.GoogleMapActionProvider
+   import com.sap.cloud.mobile.fiori.maps.google.GoogleMapViewModel
+   import com.sap.cloud.mobile.kotlin.odata.DataQuery
+   import com.sap.wizapp.R
+   import com.sap.wizapp.service.SAPServiceManager
+   import kotlinx.coroutines.runBlocking
+   import java.io.IOException
 
-    class CustomersFioriMapActivity : AppCompatActivity(), GoogleFioriMapView.OnMapCreatedListener {
-        private lateinit var mGoogleFioriMapView: GoogleFioriMapView
-        private var mUseClustering = false
-        private var mMapType: Int = 0
-        private val locations = HashMap<String, LatLng>() // Used for demo purposes to speed up the process of converting an address to lat, long
-        private val markers = HashMap<String, FioriMarkerOptions>() // Used to associate an address with a marker for search
-        private val addresses = arrayListOf<String>() // Used to populate the list of addresses that are searchable
-        private lateinit var mActionProvider: GoogleMapActionProvider
+   class CustomersFioriMapActivity : AppCompatActivity(), GoogleFioriMapView.OnMapCreatedListener {
+       private lateinit var mGoogleFioriMapView: GoogleFioriMapView
+       private var mUseClustering = false
+       private var mMapType: Int = 0
+       private val locations = HashMap<String, LatLng>() // Used for demo purposes to speed up the process of converting an address to lat, long
+       private val markers = HashMap<String, FioriMarkerOptions>() // Used to associate an address with a marker for search
+       private val addresses = arrayListOf<String>() // Used to populate the list of addresses that are searchable
+       private lateinit var mActionProvider: GoogleMapActionProvider
 
-        override fun onCreate(savedInstanceState: Bundle?) {
-            super.onCreate(savedInstanceState)
+       override fun onCreate(savedInstanceState: Bundle?) {
+           super.onCreate(savedInstanceState)
 
-            val intent = intent
-            setContentView(R.layout.activity_customers_fiori_map)
+           val intent = intent
+           setContentView(R.layout.activity_customers_fiori_map)
 
-            mGoogleFioriMapView = findViewById(R.id.googleFioriMap)
-            mGoogleFioriMapView.onCreate(savedInstanceState)
+           mGoogleFioriMapView = findViewById(R.id.googleFioriMap)
+           mGoogleFioriMapView.onCreate(savedInstanceState)
 
-            savedInstanceState?.let {
-                mUseClustering = it.getBoolean("UseClustering", false)
-                mMapType = it.getInt("MapType", GoogleMap.MAP_TYPE_NORMAL)
-            }
-            mGoogleFioriMapView.setOnMapCreatedListener(this)
-        }
+           savedInstanceState?.let {
+               mUseClustering = it.getBoolean("UseClustering", false)
+               mMapType = it.getInt("MapType", GoogleMap.MAP_TYPE_NORMAL)
+           }
+           mGoogleFioriMapView.setOnMapCreatedListener(this)
+       }
 
-        /**
-        * Manipulates the map once available.
-        * This callback is triggered when the map is ready to be used.
-        * This is where we can add markers or lines, add listeners or move the camera. In this case,
-        * we just add a marker near Toronto, Canada.
-        */
-        override fun onMapCreated() {
-            mActionProvider = GoogleMapActionProvider(mGoogleFioriMapView, this)
-            // For demo purposes, speed up the lookup of address details.
-            // Will use Geocoder to translate an address to a LatLng if address is not in this list
-            locations["Wilmington, Delaware, US"] = LatLng(39.744655, -75.5483909)
-            locations["Antioch, Illinois, US"] = LatLng(42.4772418, -88.0956396)
-            locations["Santa Clara, California, US"] = LatLng(37.354107899999995, -121.9552356)
-            locations["Hermosillo, MX"] = LatLng(29.0729673, -110.9559192)
-            locations["Bismarck, North Dakota, US"] = LatLng(46.808326799999996, -100.7837392)
-            locations["Ottawa, CA"] = LatLng(45.4215296, -75.69719309999999)
-            locations["México, MX"] = LatLng(23.634501, -102.55278399999999)
-            locations["Boca Raton, Florida, US"] = LatLng(26.368306399999998, -80.1289321)
-            locations["Carrollton, Texas, US"] = LatLng(32.9756415, -96.8899636)
-            locations["Lombard, Illinois, US"] = LatLng(41.8800296, -88.00784349999999)
-            locations["Moorestown, US"] = LatLng(39.9688817, -74.948886)
-            addCustomersToMap()
+       /**
+       * Manipulates the map once available.
+       * This callback is triggered when the map is ready to be used.
+       * This is where we can add markers or lines, add listeners or move the camera. In this case,
+       * we just add a marker near Toronto, Canada.
+       */
+       override fun onMapCreated() {
+           mActionProvider = GoogleMapActionProvider(mGoogleFioriMapView, this)
+           // For demo purposes, speed up the lookup of address details.
+           // Will use Geocoder to translate an address to a LatLng if address is not in this list
+           locations["Wilmington, Delaware, US"] = LatLng(39.744655, -75.5483909)
+           locations["Antioch, Illinois, US"] = LatLng(42.4772418, -88.0956396)
+           locations["Santa Clara, California, US"] = LatLng(37.354107899999995, -121.9552356)
+           locations["Hermosillo, MX"] = LatLng(29.0729673, -110.9559192)
+           locations["Bismarck, North Dakota, US"] = LatLng(46.808326799999996, -100.7837392)
+           locations["Ottawa, CA"] = LatLng(45.4215296, -75.69719309999999)
+           locations["México, MX"] = LatLng(23.634501, -102.55278399999999)
+           locations["Boca Raton, Florida, US"] = LatLng(26.368306399999998, -80.1289321)
+           locations["Carrollton, Texas, US"] = LatLng(32.9756415, -96.8899636)
+           locations["Lombard, Illinois, US"] = LatLng(41.8800296, -88.00784349999999)
+           locations["Moorestown, US"] = LatLng(39.9688817, -74.948886)
+           addCustomersToMap()
 
-            // Setup toolbar buttons and add to the view.
-            val settingsButton = SettingsButton(mGoogleFioriMapView.toolbar.context)
-            val legendButton = LegendButton(mGoogleFioriMapView.toolbar.context)
-            legendButton.isEnabled = true
-            val locationButton = LocationButton(mGoogleFioriMapView.toolbar.context)
-            val extentButton = ZoomExtentButton(mGoogleFioriMapView.toolbar.context)
-            val buttons = arrayOf<ImageButton>(settingsButton, legendButton, locationButton, extentButton)
-            mGoogleFioriMapView.toolbar.addButtons(buttons.asList())
+           // Setup toolbar buttons and add to the view.
+           val settingsButton = SettingsButton(mGoogleFioriMapView.toolbar.context)
+           val legendButton = LegendButton(mGoogleFioriMapView.toolbar.context)
+           legendButton.isEnabled = true
+           val locationButton = LocationButton(mGoogleFioriMapView.toolbar.context)
+           val extentButton = ZoomExtentButton(mGoogleFioriMapView.toolbar.context)
+           val buttons = arrayOf<ImageButton>(settingsButton, legendButton, locationButton, extentButton)
+           mGoogleFioriMapView.toolbar.addButtons(buttons.asList())
 
-            // Setup draggable bottom panel
-            val inflater = getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
-            val detailView = inflater.inflate(R.layout.detail_panel, null)
-            mGoogleFioriMapView.setDefaultPanelContent(detailView)
+           // Setup draggable bottom panel
+           val inflater = getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
+           val detailView = inflater.inflate(R.layout.detail_panel, null)
+           mGoogleFioriMapView.setDefaultPanelContent(detailView)
 
-            mActionProvider.setClustering(false)
+           mActionProvider.setClustering(false)
 
-            val currentPosition = (mActionProvider.mapViewModel as GoogleMapViewModel).latLng
-            val currentZoom = (mActionProvider.mapViewModel as GoogleMapViewModel).zoom
-            if (currentPosition != null && currentZoom != 0f) {
-                // Position the camera after a lifecycle event.
-                mGoogleFioriMapView.map?.moveCamera(CameraUpdateFactory.newLatLngZoom(currentPosition, currentZoom))
-            } else {
-                // Move the camera to the centre of North America
-                val centre = LatLng(39.8283, -98.5795)
-                mGoogleFioriMapView.map?.animateCamera(CameraUpdateFactory.newLatLng(centre))
-            }
+           val currentPosition = (mActionProvider.mapViewModel as GoogleMapViewModel).latLng
+           val currentZoom = (mActionProvider.mapViewModel as GoogleMapViewModel).zoom
+           if (currentPosition != null && currentZoom != 0f) {
+               // Position the camera after a lifecycle event.
+               mGoogleFioriMapView.map?.moveCamera(CameraUpdateFactory.newLatLngZoom(currentPosition, currentZoom))
+           } else {
+               // Move the camera to the centre of North America
+               val centre = LatLng(39.8283, -98.5795)
+               mGoogleFioriMapView.map?.animateCamera(CameraUpdateFactory.newLatLng(centre))
+           }
 
-            findViewById<FioriMapSearchView>(com.sap.cloud.mobile.fiori.maps.google.R.id.fiori_map_search_view)?.let {
-                val searchManager = getSystemService(Context.SEARCH_SERVICE) as SearchManager
-                it.setSearchableInfo(searchManager.getSearchableInfo(componentName))
-                it.setAdapter(ArrayAdapter(this@CustomersFioriMapActivity, R.layout.search_auto_complete, R.id.search_auto_complete_text, addresses))
-                it.setThreshold(2)
-                it.setOnItemClickListener{ parent, _, position, _ ->
-                    it.setQuery(parent.getItemAtPosition(position).toString(), false)
-                    searchResultSelected(parent.getItemAtPosition(position) as String)
-                    val inputMethodManager = getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
-                    inputMethodManager.hideSoftInputFromWindow(it.windowToken, 0) }
-            }
-        }
+           findViewById<FioriMapSearchView>(com.sap.cloud.mobile.fiori.maps.google.R.id.fiori_map_search_view)?.let {
+               val searchManager = getSystemService(Context.SEARCH_SERVICE) as SearchManager
+               it.setSearchableInfo(searchManager.getSearchableInfo(componentName))
+               it.setAdapter(ArrayAdapter(this@CustomersFioriMapActivity, R.layout.search_auto_complete, R.id.search_auto_complete_text, addresses))
+               it.setThreshold(2)
+               it.setOnItemClickListener{ parent, _, position, _ ->
+                   it.setQuery(parent.getItemAtPosition(position).toString(), false)
+                   searchResultSelected(parent.getItemAtPosition(position) as String)
+                   val inputMethodManager = getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+                   inputMethodManager.hideSoftInputFromWindow(it.windowToken, 0) }
+           }
+       }
 
-        private fun searchResultSelected(selectedSearchResult: String) {
-            locations[selectedSearchResult]?.let { latLng ->
-                // Center the marker.
-                mGoogleFioriMapView.map?.moveCamera(CameraUpdateFactory.newLatLng(latLng))
-                // Select the marker (or cluster the marker is in).
-                mActionProvider.selectMarker(markers[selectedSearchResult])
-            }
-        }
+       private fun searchResultSelected(selectedSearchResult: String) {
+           locations[selectedSearchResult]?.let { latLng ->
+               // Center the marker.
+               mGoogleFioriMapView.map?.moveCamera(CameraUpdateFactory.newLatLng(latLng))
+               // Select the marker (or cluster the marker is in).
+               mActionProvider.selectMarker(markers[selectedSearchResult])
+           }
+       }
 
-        // Methods overriding the lifecycle events are required for FioriMapView to run properly
-        override fun onStart() {
-            super.onStart()
-            mGoogleFioriMapView.onStart()
-        }
+       // Methods overriding the lifecycle events are required for FioriMapView to run properly
+       override fun onStart() {
+           super.onStart()
+           mGoogleFioriMapView.onStart()
+       }
 
-        override fun onResume() {
-            super.onResume()
-            mGoogleFioriMapView.onResume()
-        }
+       override fun onResume() {
+           super.onResume()
+           mGoogleFioriMapView.onResume()
+       }
 
-        override fun onPause() {
-            super.onPause()
-            mGoogleFioriMapView.onPause()
-        }
+       override fun onPause() {
+           super.onPause()
+           mGoogleFioriMapView.onPause()
+       }
 
-        override fun onStop() {
-            super.onStop()
-            mGoogleFioriMapView.onStop()
-        }
+       override fun onStop() {
+           super.onStop()
+           mGoogleFioriMapView.onStop()
+       }
 
-        override fun onDestroy() {
-            super.onDestroy()
-            mGoogleFioriMapView.onDestroy()
-        }
+       override fun onDestroy() {
+           super.onDestroy()
+           mGoogleFioriMapView.onDestroy()
+       }
 
-        override fun onSaveInstanceState(outState: Bundle) {
-            super.onSaveInstanceState(outState)
-            mGoogleFioriMapView.onSaveInstanceState(outState)
+       override fun onSaveInstanceState(outState: Bundle) {
+           super.onSaveInstanceState(outState)
+           mGoogleFioriMapView.onSaveInstanceState(outState)
 
-            outState.putBoolean("UseClustering", mUseClustering)
-            outState.putInt("MapType", mMapType)
-        }
+           outState.putBoolean("UseClustering", mUseClustering)
+           outState.putInt("MapType", mMapType)
+       }
 
-        @Deprecated("Deprecated in Java")
-        override fun onLowMemory() {
-            super.onLowMemory()
-            mGoogleFioriMapView.onLowMemory()
-        }
+       @Deprecated("Deprecated in Java")
+       override fun onLowMemory() {
+           super.onLowMemory()
+           mGoogleFioriMapView.onLowMemory()
+       }
 
-        private fun getCustomerLatLongFromAddress(address: String) : LatLng? {
-            locations[address]?.let {
-                return it
-            }
+       private fun getCustomerLatLongFromAddress(address: String) : LatLng? {
+           locations[address]?.let {
+               return it
+           }
 
-            // String strAddress = "Wilmington, Delaware";
-            val coder = Geocoder(this)
-            try
-            {   // May throw an IOException
-                val addresses = coder.getFromLocationName(address, 5)
-                if (addresses.isNullOrEmpty())
-                {
-                    return null
-                }
+           // String strAddress = "Wilmington, Delaware";
+           val coder = Geocoder(this)
+           try
+           {   // May throw an IOException
+               val addresses = coder.getFromLocationName(address, 5)
+               if (addresses.isNullOrEmpty())
+               {
+                   return null
+               }
 
-                val location = addresses[0]
-                return LatLng(location.latitude, location.longitude)
-            }
-            catch (ex: IOException) {
-                ex.printStackTrace()
-                return null
-            }
-        }
+               val location = addresses[0]
+               return LatLng(location.latitude, location.longitude)
+           }
+           catch (ex: IOException) {
+               ex.printStackTrace()
+               return null
+           }
+       }
 
-        private fun addCustomerMarkerToMap(customer: Customer) {
-            getCustomerLatLongFromAddress(customer.city + ", " + customer.country)?.let {latLng ->
-                val customerMarker = FioriMarkerOptions.Builder()
-                    .tag(customer)
-                    .point(FioriPoint(latLng.latitude, latLng.longitude))
-                    .title(customer.firstName + " " + customer.lastName)
-                    .legendTitle("Customer")
-                    .build()
-                mActionProvider.addMarker(customerMarker)
-                markers[customer.city + ", " + customer.country] = customerMarker
-                mGoogleFioriMapView.map?.moveCamera(CameraUpdateFactory.newLatLng(latLng))
-            }
-        }
+       private fun addCustomerMarkerToMap(customer: Customer) {
+           getCustomerLatLongFromAddress(customer.city + ", " + customer.country)?.let {latLng ->
+               val customerMarker = FioriMarkerOptions.Builder()
+                   .tag(customer)
+                   .point(FioriPoint(latLng.latitude, latLng.longitude))
+                   .title(customer.firstName + " " + customer.lastName)
+                   .legendTitle("Customer")
+                   .build()
+               mActionProvider.addMarker(customerMarker)
+               markers[customer.city + ", " + customer.country] = customerMarker
+               mGoogleFioriMapView.map?.moveCamera(CameraUpdateFactory.newLatLng(latLng))
+           }
+       }
 
-        private fun addCustomersToMap() {
-            val query = DataQuery()
-                .from(ESPMContainerMetadata.EntitySets.customers)
-                .where(Customer.country.equal("US")
-                    .or(Customer.country.equal("CA"))
-                    .or(Customer.country.equal("MX")))
-            val eSPMContainer = SAPServiceManager.eSPMContainer
-            eSPMContainer?.let {
-                runBlocking {
-                    it.getCustomers(query).also { customers ->
-                        for (customer in customers)
-                        {
-                            addCustomerMarkerToMap(customer)
-                            addresses.add(customer.city + ", " + customer.country)
-                        }
-                        mActionProvider.doExtentsAction()
-                    }
-                }
-            }
-        }
-    }
-    ```
+       private fun addCustomersToMap() {
+           val query = DataQuery()
+               .from(ESPMContainerMetadata.EntitySets.customers)
+               .where(Customer.country.equal("US")
+                   .or(Customer.country.equal("CA"))
+                   .or(Customer.country.equal("MX")))
+           val eSPMContainer = SAPServiceManager.eSPMContainer
+           eSPMContainer?.let {
+               runBlocking {
+                   it.getCustomers(query).also { customers ->
+                       for (customer in customers)
+                       {
+                           addCustomerMarkerToMap(customer)
+                           addresses.add(customer.city + ", " + customer.country)
+                       }
+                       mActionProvider.doExtentsAction()
+                   }
+               }
+           }
+       }
+   }
+   ```
 
 11. Press **Shift** twice and type **`activity_customers_fiori_map.xml`** to open `activity_customers_fiori_map.xml`.
 
 12. Replace its contents with the following code.
 
-    ```XML
-    <?xml version="1.0" encoding="utf-8"?>
-    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:id="@+id/main"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fitsSystemWindows="true"
-        tools:context=".ui.CustomersFioriMapActivity">
+   ```XML
+   <?xml version="1.0" encoding="utf-8"?>
+   <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:app="http://schemas.android.com/apk/res-auto"
+       xmlns:tools="http://schemas.android.com/tools"
+       android:id="@+id/main"
+       android:layout_width="match_parent"
+       android:layout_height="match_parent"
+       android:fitsSystemWindows="true"
+       tools:context=".ui.CustomersFioriMapActivity">
 
-        <com.sap.cloud.mobile.fiori.maps.google.GoogleFioriMapView
-            android:id="@+id/googleFioriMap"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            />
+       <com.sap.cloud.mobile.fiori.maps.google.GoogleFioriMapView
+           android:id="@+id/googleFioriMap"
+           android:layout_width="match_parent"
+           android:layout_height="match_parent"
+           />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
-    ```
+   </androidx.constraintlayout.widget.ConstraintLayout>
+   ```
 
 13. Right-click on the folder `app/src/main/res/layout` to create a new **Layout Resource File** in it called **`detail_panel.xml`** and replace its contents with the following code.
 
-    ```XML
-    <?xml version="1.0" encoding="utf-8"?>
-    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:layout_constraintVertical_weight="100">
+   ```XML
+   <?xml version="1.0" encoding="utf-8"?>
+   <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:tools="http://schemas.android.com/tools"
+       android:layout_width="match_parent"
+       android:layout_height="match_parent"
+       tools:layout_constraintVertical_weight="100">
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:paddingTop="4dp"
-            android:paddingLeft="4dp"
-            android:text="Default panel content goes here" />
+       <TextView
+           android:layout_width="match_parent"
+           android:layout_height="match_parent"
+           android:paddingTop="4dp"
+           android:paddingLeft="4dp"
+           android:text="Default panel content goes here" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
-    ```
+   </androidx.constraintlayout.widget.ConstraintLayout>
+   ```
 
 14. Create a new **Layout Resource File** in `app/src/main/res/layout` called **`search_auto_complete.xml`** and replace its contents with the following code.
 
-    ```XML
-    <?xml version="1.0" encoding="utf-8"?>
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/search_auto_complete_text"
-            android:layout_width="match_parent"
-            android:layout_height="50dp" />
+   ```XML
+   <?xml version="1.0" encoding="utf-8"?>
+   <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:app="http://schemas.android.com/apk/res-auto"
+       android:layout_width="match_parent"
+       android:layout_height="match_parent">
+       <androidx.appcompat.widget.AppCompatTextView
+           android:id="@+id/search_auto_complete_text"
+           android:layout_width="match_parent"
+           android:layout_height="50dp" />
 
-    </LinearLayout>
-    ```
+   </LinearLayout>
+   ```
 
 15. On Windows, press **`Ctrl+Shift+N`**, or on a Mac, press **`command+shift+O`**, and type **`EntitySetsScreen`** to open `EntitySetsScreen.kt`.
 
 16. Declare a context variable right before `FioriObjectCell(`:
 
-    ```Kotlin
-    val context = LocalContext.current
-    ```
+   ```Kotlin
+   val context = LocalContext.current
+   ```
 
 17. On Windows, press **`Ctrl+F`**, or on a Mac, press **`command+F`**, and search for **`onClick`**.
 
 18. Replace `onClick` parameter with the following code so that when the user taps on **Customers**, the app will navigate to the newly added activity with the Fiori map on it.
 
-    ```Kotlin
-    onClick = {
-        if (item.entityType == ESPMContainerMetadata.EntityTypes.customer) {
-            context.startActivity(Intent(context, CustomersFioriMapActivity::class.java))
-        } else {
-            onRowClick(
-                item.entityType
-            )
-        }
-    }
-    ```
+   ```Kotlin
+   onClick = {
+       if (item.entityType == ESPMContainerMetadata.EntityTypes.customer) {
+           context.startActivity(Intent(context, CustomersFioriMapActivity::class.java))
+       } else {
+           onRowClick(
+               item.entityType
+           )
+       }
+   }
+   ```
 
 19. Add the necessary imports to the top of the file if they are not auto-imported.
 
-    ```Kotlin
-    import android.content.Intent
-    import com.sap.wizapp.ui.CustomersFioriMapActivity
-    import com.sap.cloud.android.odata.espmcontainer.ESPMContainerMetadata
-    ```
+   ```Kotlin
+   import android.content.Intent
+   import com.sap.wizapp.ui.CustomersFioriMapActivity
+   import com.sap.cloud.android.odata.espmcontainer.ESPMContainerMetadata
+   ```
 
 20. On Windows, press **`Ctrl+Shift+N`**, or on a Mac, press **`command+shift+O`**, and type **`AndroidManifest`** to open `AndroidManifest.xml`.
 
@@ -1037,12 +1037,12 @@ In this section, you will create a new activity that uses the Fiori Map control.
 
 22. Modify the activity so it specifies the `NoActionBar` theme, which will cause the activity to not display an action bar.
 
-    ```XML
-    <activity
-        android:name=".ui.CustomersFioriMapActivity"
-        android:theme="@style/FioriMap.NoActionBar"
-        android:exported="false" />
-    ```
+   ```XML
+   <activity
+       android:name=".ui.CustomersFioriMapActivity"
+       android:theme="@style/FioriMap.NoActionBar"
+       android:exported="false" />
+   ```
 
 23. Run the app.
 
@@ -1070,56 +1070,56 @@ In this section, you will create a new activity that uses the Fiori Map control.
 
 2. Add the following code right after `AppTheme` and before `AppTheme.NoActionBar`:
 
-    ```XML
-    <style name="FioriMap.NoActionBar" parent="FioriTheme.Onboarding">
-        <item name="colorPrimary">?attr/sap_fiori_color_s2</item>
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
-        <item name="windowActionModeOverlay">true</item>
-    </style>
-    ```
+   ```XML
+   <style name="FioriMap.NoActionBar" parent="FioriTheme.Onboarding">
+       <item name="colorPrimary">?attr/sap_fiori_color_s2</item>
+       <item name="windowActionBar">false</item>
+       <item name="windowNoTitle">true</item>
+       <item name="windowActionModeOverlay">true</item>
+   </style>
+   ```
 
 3. Add the following dependency in the app module's `build.gradle` file in the dependencies object and click **Sync Now**.
 
-    ```Gradle
-    implementation group: 'com.sap.cloud.android', name: 'google-maps', version: sdkVersion
-    ```
+   ```Gradle
+   implementation group: 'com.sap.cloud.android', name: 'google-maps', version: sdkVersion
+   ```
 
 4. Right-click on the folder `app/src/main/res/layout` to create a new **Layout Resource File** in it called **`detail_panel.xml`** and replace its contents with the following code.
 
-    ```XML
-    <?xml version="1.0" encoding="utf-8"?>
-    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:layout_constraintVertical_weight="100">
+   ```XML
+   <?xml version="1.0" encoding="utf-8"?>
+   <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:tools="http://schemas.android.com/tools"
+       android:layout_width="match_parent"
+       android:layout_height="match_parent"
+       tools:layout_constraintVertical_weight="100">
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:paddingTop="4dp"
-            android:paddingLeft="4dp"
-            android:text="Default panel content goes here" />
+       <TextView
+           android:layout_width="match_parent"
+           android:layout_height="match_parent"
+           android:paddingTop="4dp"
+           android:paddingLeft="4dp"
+           android:text="Default panel content goes here" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
-    ```
+   </androidx.constraintlayout.widget.ConstraintLayout>
+   ```
 
 5. Create a new **Layout Resource File** in `app/src/main/res/layout` called **`search_auto_complete.xml`** and replace its contents with the following code.
 
-    ```XML
-    <?xml version="1.0" encoding="utf-8"?>
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/search_auto_complete_text"
-            android:layout_width="match_parent"
-            android:layout_height="50dp" />
+   ```XML
+   <?xml version="1.0" encoding="utf-8"?>
+   <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:app="http://schemas.android.com/apk/res-auto"
+       android:layout_width="match_parent"
+       android:layout_height="match_parent">
+       <androidx.appcompat.widget.AppCompatTextView
+           android:id="@+id/search_auto_complete_text"
+           android:layout_width="match_parent"
+           android:layout_height="50dp" />
 
-    </LinearLayout>
-    ```
+   </LinearLayout>
+   ```
 
 6. In Android Studio, using the project explorer, navigate to **`app > kotlin+java > com.sap.wizapp > mdui > customers`**.
 
@@ -1131,259 +1131,259 @@ In this section, you will create a new activity that uses the Fiori Map control.
 
 10. Replace the file contents in the newly created `CustomersFioriMapActivity.kt` with the following code:
 
-    ```Kotlin
-    package com.sap.wizapp.mdui.customers
+   ```Kotlin
+   package com.sap.wizapp.mdui.customers
 
-    import android.app.SearchManager
-    import android.content.Context
-    import android.location.Geocoder
-    import android.os.Bundle
-    import android.util.Log
-    import android.view.LayoutInflater
-    import android.view.inputmethod.InputMethodManager
-    import android.widget.ArrayAdapter
-    import android.widget.ImageButton
-    import androidx.appcompat.app.AppCompatActivity
-    import com.google.android.gms.maps.CameraUpdateFactory
-    import com.google.android.gms.maps.GoogleMap
-    import com.google.android.gms.maps.model.LatLng
-    import com.sap.cloud.android.odata.espmcontainer.Customer
-    import com.sap.cloud.android.odata.espmcontainer.ESPMContainerMetadata
-    import com.sap.cloud.mobile.fiori.maps.FioriMapSearchView
-    import com.sap.cloud.mobile.fiori.maps.FioriMarkerOptions
-    import com.sap.cloud.mobile.fiori.maps.FioriPoint
-    import com.sap.cloud.mobile.fiori.maps.LegendButton
-    import com.sap.cloud.mobile.fiori.maps.LocationButton
-    import com.sap.cloud.mobile.fiori.maps.SettingsButton
-    import com.sap.cloud.mobile.fiori.maps.ZoomExtentButton
-    import com.sap.cloud.mobile.fiori.maps.google.GoogleFioriMapView
-    import com.sap.cloud.mobile.fiori.maps.google.GoogleMapActionProvider
-    import com.sap.cloud.mobile.fiori.maps.google.GoogleMapViewModel
-    import com.sap.cloud.mobile.odata.DataQuery
-    import com.sap.wizapp.R
-    import com.sap.wizapp.app.SAPWizardApplication
-    import java.io.IOException
+   import android.app.SearchManager
+   import android.content.Context
+   import android.location.Geocoder
+   import android.os.Bundle
+   import android.util.Log
+   import android.view.LayoutInflater
+   import android.view.inputmethod.InputMethodManager
+   import android.widget.ArrayAdapter
+   import android.widget.ImageButton
+   import androidx.appcompat.app.AppCompatActivity
+   import com.google.android.gms.maps.CameraUpdateFactory
+   import com.google.android.gms.maps.GoogleMap
+   import com.google.android.gms.maps.model.LatLng
+   import com.sap.cloud.android.odata.espmcontainer.Customer
+   import com.sap.cloud.android.odata.espmcontainer.ESPMContainerMetadata
+   import com.sap.cloud.mobile.fiori.maps.FioriMapSearchView
+   import com.sap.cloud.mobile.fiori.maps.FioriMarkerOptions
+   import com.sap.cloud.mobile.fiori.maps.FioriPoint
+   import com.sap.cloud.mobile.fiori.maps.LegendButton
+   import com.sap.cloud.mobile.fiori.maps.LocationButton
+   import com.sap.cloud.mobile.fiori.maps.SettingsButton
+   import com.sap.cloud.mobile.fiori.maps.ZoomExtentButton
+   import com.sap.cloud.mobile.fiori.maps.google.GoogleFioriMapView
+   import com.sap.cloud.mobile.fiori.maps.google.GoogleMapActionProvider
+   import com.sap.cloud.mobile.fiori.maps.google.GoogleMapViewModel
+   import com.sap.cloud.mobile.odata.DataQuery
+   import com.sap.wizapp.R
+   import com.sap.wizapp.app.SAPWizardApplication
+   import java.io.IOException
 
-    class CustomersFioriMapActivity : AppCompatActivity(), GoogleFioriMapView.OnMapCreatedListener {
-        private lateinit var mGoogleFioriMapView: GoogleFioriMapView
-        private var mUseClustering = false
-        private var mMapType: Int = 0
-        private val locations = HashMap<String, LatLng>() // Used for demo purposes to speed up the process of converting an address to lat, long
-        private val markers = HashMap<String, FioriMarkerOptions>() // Used to associate an address with a marker for search
-        private val addresses = arrayListOf<String>() // Used to populate the list of addresses that are searchable
-        private lateinit var mActionProvider: GoogleMapActionProvider
+   class CustomersFioriMapActivity : AppCompatActivity(), GoogleFioriMapView.OnMapCreatedListener {
+       private lateinit var mGoogleFioriMapView: GoogleFioriMapView
+       private var mUseClustering = false
+       private var mMapType: Int = 0
+       private val locations = HashMap<String, LatLng>() // Used for demo purposes to speed up the process of converting an address to lat, long
+       private val markers = HashMap<String, FioriMarkerOptions>() // Used to associate an address with a marker for search
+       private val addresses = arrayListOf<String>() // Used to populate the list of addresses that are searchable
+       private lateinit var mActionProvider: GoogleMapActionProvider
 
-        override fun onCreate(savedInstanceState: Bundle?) {
-            super.onCreate(savedInstanceState)
+       override fun onCreate(savedInstanceState: Bundle?) {
+           super.onCreate(savedInstanceState)
 
-            val intent = intent
-            setContentView(R.layout.activity_customers_fiori_map)
+           val intent = intent
+           setContentView(R.layout.activity_customers_fiori_map)
 
-            mGoogleFioriMapView = findViewById(R.id.googleFioriMap)
-            mGoogleFioriMapView.onCreate(savedInstanceState)
+           mGoogleFioriMapView = findViewById(R.id.googleFioriMap)
+           mGoogleFioriMapView.onCreate(savedInstanceState)
 
-            savedInstanceState?.let {
-                mUseClustering = it.getBoolean("UseClustering", false)
-                mMapType = it.getInt("MapType", GoogleMap.MAP_TYPE_NORMAL)
-            }
-            mGoogleFioriMapView.setOnMapCreatedListener(this)
-        }
+           savedInstanceState?.let {
+               mUseClustering = it.getBoolean("UseClustering", false)
+               mMapType = it.getInt("MapType", GoogleMap.MAP_TYPE_NORMAL)
+           }
+           mGoogleFioriMapView.setOnMapCreatedListener(this)
+       }
 
-        /**
-         * Manipulates the map once available.
-         * This callback is triggered when the map is ready to be used.
-         * This is where we can add markers or lines, add listeners or move the camera. In this case,
-         * we just add a marker near Toronto, Canada.
-         */
-        override fun onMapCreated() {
-            mActionProvider = GoogleMapActionProvider(mGoogleFioriMapView, this)
-            // For demo purposes, speed up the lookup of address details.
-            // Will use Geocoder to translate an address to a LatLng if address is not in this list
-            locations.put("Wilmington, Delaware, US", LatLng(39.744655, -75.5483909))
-            locations.put("Antioch, Illinois, US", LatLng(42.4772418, -88.0956396))
-            locations.put("Santa Clara, California, US", LatLng(37.354107899999995, -121.9552356))
-            locations.put("Hermosillo, MX", LatLng(29.0729673, -110.9559192))
-            locations.put("Bismarck, North Dakota, US", LatLng(46.808326799999996, -100.7837392))
-            locations.put("Ottawa, CA", LatLng(45.4215296, -75.69719309999999))
-            locations.put("México, MX", LatLng(23.634501, -102.55278399999999))
-            locations.put("Boca Raton, Florida, US", LatLng(26.368306399999998, -80.1289321))
-            locations.put("Carrollton, Texas, US", LatLng(32.9756415, -96.8899636))
-            locations.put("Lombard, Illinois, US", LatLng(41.8800296, -88.00784349999999))
-            locations.put("Moorestown, US", LatLng(39.9688817, -74.948886))
-            addCustomersToMap()
+       /**
+        * Manipulates the map once available.
+        * This callback is triggered when the map is ready to be used.
+        * This is where we can add markers or lines, add listeners or move the camera. In this case,
+        * we just add a marker near Toronto, Canada.
+        */
+       override fun onMapCreated() {
+           mActionProvider = GoogleMapActionProvider(mGoogleFioriMapView, this)
+           // For demo purposes, speed up the lookup of address details.
+           // Will use Geocoder to translate an address to a LatLng if address is not in this list
+           locations.put("Wilmington, Delaware, US", LatLng(39.744655, -75.5483909))
+           locations.put("Antioch, Illinois, US", LatLng(42.4772418, -88.0956396))
+           locations.put("Santa Clara, California, US", LatLng(37.354107899999995, -121.9552356))
+           locations.put("Hermosillo, MX", LatLng(29.0729673, -110.9559192))
+           locations.put("Bismarck, North Dakota, US", LatLng(46.808326799999996, -100.7837392))
+           locations.put("Ottawa, CA", LatLng(45.4215296, -75.69719309999999))
+           locations.put("México, MX", LatLng(23.634501, -102.55278399999999))
+           locations.put("Boca Raton, Florida, US", LatLng(26.368306399999998, -80.1289321))
+           locations.put("Carrollton, Texas, US", LatLng(32.9756415, -96.8899636))
+           locations.put("Lombard, Illinois, US", LatLng(41.8800296, -88.00784349999999))
+           locations.put("Moorestown, US", LatLng(39.9688817, -74.948886))
+           addCustomersToMap()
 
-            // Setup toolbar buttons and add to the view.
-            val settingsButton = SettingsButton(mGoogleFioriMapView.toolbar.context)
-            val legendButton = LegendButton(mGoogleFioriMapView.toolbar.context)
-            legendButton.isEnabled = true
-            val locationButton = LocationButton(mGoogleFioriMapView.toolbar.context)
-            val extentButton = ZoomExtentButton(mGoogleFioriMapView.toolbar.context)
-            val buttons = arrayOf<ImageButton>(settingsButton, legendButton, locationButton, extentButton)
-            mGoogleFioriMapView.toolbar.addButtons(buttons.asList())
+           // Setup toolbar buttons and add to the view.
+           val settingsButton = SettingsButton(mGoogleFioriMapView.toolbar.context)
+           val legendButton = LegendButton(mGoogleFioriMapView.toolbar.context)
+           legendButton.isEnabled = true
+           val locationButton = LocationButton(mGoogleFioriMapView.toolbar.context)
+           val extentButton = ZoomExtentButton(mGoogleFioriMapView.toolbar.context)
+           val buttons = arrayOf<ImageButton>(settingsButton, legendButton, locationButton, extentButton)
+           mGoogleFioriMapView.toolbar.addButtons(buttons.asList())
 
-            // Setup draggable bottom panel
-            val inflater = getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
-            val detailView = inflater.inflate(R.layout.detail_panel, null)
-            mGoogleFioriMapView.setDefaultPanelContent(detailView)
+           // Setup draggable bottom panel
+           val inflater = getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
+           val detailView = inflater.inflate(R.layout.detail_panel, null)
+           mGoogleFioriMapView.setDefaultPanelContent(detailView)
 
-            mActionProvider.setClustering(false)
+           mActionProvider.setClustering(false)
 
-            val currentPosition = (mActionProvider.mapViewModel as GoogleMapViewModel).latLng
-            val currentZoom = (mActionProvider.mapViewModel as GoogleMapViewModel).zoom
-            if (currentPosition != null && currentZoom != 0f)
-            {
-                // Position the camera after a lifecycle event.
-                mGoogleFioriMapView.map?.moveCamera(CameraUpdateFactory.newLatLngZoom(currentPosition, currentZoom))
-            }
-            else
-            {
-                // Move the camera to the centre of North America
-                val centre = LatLng(39.8283, -98.5795)
-                mGoogleFioriMapView.map?.animateCamera(CameraUpdateFactory.newLatLng(centre))
-            }
+           val currentPosition = (mActionProvider.mapViewModel as GoogleMapViewModel).latLng
+           val currentZoom = (mActionProvider.mapViewModel as GoogleMapViewModel).zoom
+           if (currentPosition != null && currentZoom != 0f)
+           {
+               // Position the camera after a lifecycle event.
+               mGoogleFioriMapView.map?.moveCamera(CameraUpdateFactory.newLatLngZoom(currentPosition, currentZoom))
+           }
+           else
+           {
+               // Move the camera to the centre of North America
+               val centre = LatLng(39.8283, -98.5795)
+               mGoogleFioriMapView.map?.animateCamera(CameraUpdateFactory.newLatLng(centre))
+           }
 
-            findViewById<FioriMapSearchView>(R.id.fiori_map_search_view)?.let {
-                val searchManager = getSystemService(Context.SEARCH_SERVICE) as SearchManager
-                it.setSearchableInfo(searchManager.getSearchableInfo(componentName))
-                it.setAdapter(ArrayAdapter<String>(this@CustomersFioriMapActivity, R.layout.search_auto_complete, R.id.search_auto_complete_text, addresses))
-                it.setThreshold(2)
-                it.setOnItemClickListener{ parent, view, position, id ->
-                    it.setQuery(parent.getItemAtPosition(position).toString(), false)
-                    searchResultSelected(parent.getItemAtPosition(position) as String)
-                    val inputMethodManager = getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
-                    inputMethodManager.hideSoftInputFromWindow(it.windowToken, 0) }
-            }
-        }
+           findViewById<FioriMapSearchView>(R.id.fiori_map_search_view)?.let {
+               val searchManager = getSystemService(Context.SEARCH_SERVICE) as SearchManager
+               it.setSearchableInfo(searchManager.getSearchableInfo(componentName))
+               it.setAdapter(ArrayAdapter<String>(this@CustomersFioriMapActivity, R.layout.search_auto_complete, R.id.search_auto_complete_text, addresses))
+               it.setThreshold(2)
+               it.setOnItemClickListener{ parent, view, position, id ->
+                   it.setQuery(parent.getItemAtPosition(position).toString(), false)
+                   searchResultSelected(parent.getItemAtPosition(position) as String)
+                   val inputMethodManager = getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+                   inputMethodManager.hideSoftInputFromWindow(it.windowToken, 0) }
+           }
+       }
 
-        private fun searchResultSelected(selectedSearchResult: String) {
-            locations[selectedSearchResult]?.let { latLng ->
-                // Center the marker.
-                mGoogleFioriMapView.map?.moveCamera(CameraUpdateFactory.newLatLng(latLng))
-                // Select the marker (or cluster the marker is in).
-                mActionProvider.selectMarker(markers[selectedSearchResult])
-            }
-        }
+       private fun searchResultSelected(selectedSearchResult: String) {
+           locations[selectedSearchResult]?.let { latLng ->
+               // Center the marker.
+               mGoogleFioriMapView.map?.moveCamera(CameraUpdateFactory.newLatLng(latLng))
+               // Select the marker (or cluster the marker is in).
+               mActionProvider.selectMarker(markers[selectedSearchResult])
+           }
+       }
 
-        // Methods overriding the lifecycle events are required for FioriMapView to run properly
-        override fun onStart() {
-            super.onStart()
-            mGoogleFioriMapView.onStart()
-        }
+       // Methods overriding the lifecycle events are required for FioriMapView to run properly
+       override fun onStart() {
+           super.onStart()
+           mGoogleFioriMapView.onStart()
+       }
 
-        override fun onResume() {
-            super.onResume()
-            mGoogleFioriMapView.onResume()
-        }
+       override fun onResume() {
+           super.onResume()
+           mGoogleFioriMapView.onResume()
+       }
 
-        override fun onPause() {
-            super.onPause()
-            mGoogleFioriMapView.onPause()
-        }
+       override fun onPause() {
+           super.onPause()
+           mGoogleFioriMapView.onPause()
+       }
 
-        override fun onStop() {
-            super.onStop()
-            mGoogleFioriMapView.onStop()
-        }
+       override fun onStop() {
+           super.onStop()
+           mGoogleFioriMapView.onStop()
+       }
 
-        override fun onDestroy() {
-            super.onDestroy()
-            mGoogleFioriMapView.onDestroy()
-        }
+       override fun onDestroy() {
+           super.onDestroy()
+           mGoogleFioriMapView.onDestroy()
+       }
 
-        override fun onSaveInstanceState(bundle: Bundle) {
-            super.onSaveInstanceState(bundle)
-            mGoogleFioriMapView.onSaveInstanceState(bundle)
+       override fun onSaveInstanceState(bundle: Bundle) {
+           super.onSaveInstanceState(bundle)
+           mGoogleFioriMapView.onSaveInstanceState(bundle)
 
-            bundle.putBoolean("UseClustering", mUseClustering)
-            bundle.putInt("MapType", mMapType)
-        }
+           bundle.putBoolean("UseClustering", mUseClustering)
+           bundle.putInt("MapType", mMapType)
+       }
 
-        override fun onLowMemory() {
-            super.onLowMemory()
-            mGoogleFioriMapView.onLowMemory()
-        }
+       override fun onLowMemory() {
+           super.onLowMemory()
+           mGoogleFioriMapView.onLowMemory()
+       }
 
-        private fun getCustomerLatLongFromAddress(address: String) : LatLng? {
-            locations[address]?.let {
-                return it
-            }
+       private fun getCustomerLatLongFromAddress(address: String) : LatLng? {
+           locations[address]?.let {
+               return it
+           }
 
-            // String strAddress = "Wilmington, Delaware";
-            val coder = Geocoder(this)
-            try
-            {   // May throw an IOException
-                val addresses = coder.getFromLocationName(address, 5)
-                if (addresses.isNullOrEmpty())
-                {
-                    return null
-                }
+           // String strAddress = "Wilmington, Delaware";
+           val coder = Geocoder(this)
+           try
+           {   // May throw an IOException
+               val addresses = coder.getFromLocationName(address, 5)
+               if (addresses.isNullOrEmpty())
+               {
+                   return null
+               }
 
-                val location = addresses[0]
-                return LatLng(location.latitude, location.longitude)
-            }
-            catch (ex: IOException) {
-                ex.printStackTrace()
-                return null
-            }
-        }
+               val location = addresses[0]
+               return LatLng(location.latitude, location.longitude)
+           }
+           catch (ex: IOException) {
+               ex.printStackTrace()
+               return null
+           }
+       }
 
-        private fun addCustomerMarkerToMap(customer: Customer) {
-            getCustomerLatLongFromAddress(customer.city + ", " + customer.country)?.let {latLng ->
-                val customerMarker = FioriMarkerOptions.Builder()
-                        .tag(customer)
-                        .point(FioriPoint(latLng.latitude, latLng.longitude))
-                        .title(customer.firstName + " " + customer.lastName)
-                        .legendTitle("Customer")
-                        .build()
-                mActionProvider.addMarker(customerMarker)
-                markers.put(customer.city + ", " + customer.country, customerMarker)
-                mGoogleFioriMapView.map?.moveCamera(CameraUpdateFactory.newLatLng(latLng))
-            }
-        }
+       private fun addCustomerMarkerToMap(customer: Customer) {
+           getCustomerLatLongFromAddress(customer.city + ", " + customer.country)?.let {latLng ->
+               val customerMarker = FioriMarkerOptions.Builder()
+                       .tag(customer)
+                       .point(FioriPoint(latLng.latitude, latLng.longitude))
+                       .title(customer.firstName + " " + customer.lastName)
+                       .legendTitle("Customer")
+                       .build()
+               mActionProvider.addMarker(customerMarker)
+               markers.put(customer.city + ", " + customer.country, customerMarker)
+               mGoogleFioriMapView.map?.moveCamera(CameraUpdateFactory.newLatLng(latLng))
+           }
+       }
 
-        private fun addCustomersToMap() {
-            val query = DataQuery()
-                    .from(ESPMContainerMetadata.EntitySets.customers)
-                    .where(Customer.country.equal("US")
-                            .or(Customer.country.equal("CA"))
-                            .or(Customer.country.equal("MX")))
-            val sapServiceManager = (application as SAPWizardApplication).sapServiceManager
-            val eSPMContainer = sapServiceManager?.eSPMContainer
-            eSPMContainer?.let {
-                it.getCustomersAsync(query, { customers: List<Customer> ->
-                    for (customer in customers)
-                    {
-                        addCustomerMarkerToMap(customer)
-                        addresses.add(customer.city + ", " + customer.country)
-                    }
-                    mActionProvider.doExtentsAction() }, { re: RuntimeException -> Log.d("", "An error occurred during async query: " + re.message) })
-            }
-        }
-    }
-    ```
+       private fun addCustomersToMap() {
+           val query = DataQuery()
+                   .from(ESPMContainerMetadata.EntitySets.customers)
+                   .where(Customer.country.equal("US")
+                           .or(Customer.country.equal("CA"))
+                           .or(Customer.country.equal("MX")))
+           val sapServiceManager = (application as SAPWizardApplication).sapServiceManager
+           val eSPMContainer = sapServiceManager?.eSPMContainer
+           eSPMContainer?.let {
+               it.getCustomersAsync(query, { customers: List<Customer> ->
+                   for (customer in customers)
+                   {
+                       addCustomerMarkerToMap(customer)
+                       addresses.add(customer.city + ", " + customer.country)
+                   }
+                   mActionProvider.doExtentsAction() }, { re: RuntimeException -> Log.d("", "An error occurred during async query: " + re.message) })
+           }
+       }
+   }
+   ```
 
 11. Press **Shift** twice and type **`activity_customers_fiori_map.xml`** to open `activity_customers_fiori_map.xml`.
 
 12. Replace its contents with the following code.
 
-    ```XML
-    <?xml version="1.0" encoding="utf-8"?>
-    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fitsSystemWindows="true"
-        tools:context=".mdui.customers.CustomersFioriMapActivity">
+   ```XML
+   <?xml version="1.0" encoding="utf-8"?>
+   <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:app="http://schemas.android.com/apk/res-auto"
+       xmlns:tools="http://schemas.android.com/tools"
+       android:layout_width="match_parent"
+       android:layout_height="match_parent"
+       android:fitsSystemWindows="true"
+       tools:context=".mdui.customers.CustomersFioriMapActivity">
 
-        <com.sap.cloud.mobile.fiori.maps.google.GoogleFioriMapView
-            android:id="@+id/googleFioriMap"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            />
+       <com.sap.cloud.mobile.fiori.maps.google.GoogleFioriMapView
+           android:id="@+id/googleFioriMap"
+           android:layout_width="match_parent"
+           android:layout_height="match_parent"
+           />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
-    ```
+   </androidx.constraintlayout.widget.ConstraintLayout>
+   ```
 
 13. On Windows, press **`Ctrl+N`**, or, on a Mac, press **`command+O`**, and type **`EntitySetListActivity`** to open `EntitySetListActivity.kt`.
 
@@ -1397,12 +1397,12 @@ In this section, you will create a new activity that uses the Fiori Map control.
 
 18. Modify the activity so it specifies the `NoActionBar` theme, which will cause the activity to not display an action bar.
 
-    ```XML
-    <activity
-        android:name=".mdui.customers.CustomersFioriMapActivity"
-        android:theme="@style/FioriMap.NoActionBar"
-        android:exported="false" />
-    ```
+   ```XML
+   <activity
+       android:name=".mdui.customers.CustomersFioriMapActivity"
+       android:theme="@style/FioriMap.NoActionBar"
+       android:exported="false" />
+   ```
 
 19. Run the app.
 
@@ -1436,211 +1436,211 @@ In this section, the bottom panel will be populated with details of the selected
 
 2.  At the top of the class, add the following variables:
 
-    ```Kotlin
-    private lateinit var mMapResultsAdapter: MapResultsAdapter
-    ```
+   ```Kotlin
+   private lateinit var mMapResultsAdapter: MapResultsAdapter
+   ```
 
 3.  At the bottom of the class, add the following methods and the `MapResultsAdapter` class.
 
-    ```Kotlin
-    private fun setupInfoProvider() {
-        val infoAdapter = object: AnnotationInfoAdapter {
-            override fun getInfo(tag: Any) : Any {
-                return tag
-            }
+   ```Kotlin
+   private fun setupInfoProvider() {
+       val infoAdapter = object: AnnotationInfoAdapter {
+           override fun getInfo(tag: Any) : Any {
+               return tag
+           }
 
-            override fun onBindView(mapPreviewPanel: MapPreviewPanel, info: Any) {
-                val customer = info as Customer
-                mapPreviewPanel.setTitle(customer.firstName + " " + customer.lastName)
+           override fun onBindView(mapPreviewPanel: MapPreviewPanel, info: Any) {
+               val customer = info as Customer
+               mapPreviewPanel.setTitle(customer.firstName + " " + customer.lastName)
 
-                val objectHeader = mapPreviewPanel.objectHeader
-                objectHeader.apply {
-                    headline = customer.city + ", " + customer.country
-                    val customerLatLng = getCustomerLatLongFromAddress(customer.city + ", " + customer.country)
-                    customerLatLng?.let {
-                        body = "Latitude: " + it.latitude
-                        footnote = "Longitude " + it.longitude
-                    }
-                }
+               val objectHeader = mapPreviewPanel.objectHeader
+               objectHeader.apply {
+                   headline = customer.city + ", " + customer.country
+                   val customerLatLng = getCustomerLatLongFromAddress(customer.city + ", " + customer.country)
+                   customerLatLng?.let {
+                       body = "Latitude: " + it.latitude
+                       footnote = "Longitude " + it.longitude
+                   }
+               }
 
-                val cell = ActionCell(this@CustomersFioriMapActivity)
-                cell.apply {
-                    setText(customer.phoneNumber)
-                    setIcon(com.sap.cloud.mobile.fiori.compose.R.drawable.ic_phone_black_24dp)
-                }
+               val cell = ActionCell(this@CustomersFioriMapActivity)
+               cell.apply {
+                   setText(customer.phoneNumber)
+                   setIcon(com.sap.cloud.mobile.fiori.compose.R.drawable.ic_phone_black_24dp)
+               }
 
-                val cell2 = ActionCell(this@CustomersFioriMapActivity)
-                cell2.apply {
-                    setText(customer.emailAddress)
-                    setIcon(com.sap.cloud.mobile.fiori.compose.R.drawable.ic_email_black_24dp)
-                }
+               val cell2 = ActionCell(this@CustomersFioriMapActivity)
+               cell2.apply {
+                   setText(customer.emailAddress)
+                   setIcon(com.sap.cloud.mobile.fiori.compose.R.drawable.ic_email_black_24dp)
+               }
 
-                val cell3 = ActionCell(this@CustomersFioriMapActivity)
-                cell3.apply {
-                    setText(customer.houseNumber + " " + customer.street)
-                    setIcon(com.sap.cloud.mobile.fiori.compose.R.drawable.ic_map_marker_unselected)
-                }
+               val cell3 = ActionCell(this@CustomersFioriMapActivity)
+               cell3.apply {
+                   setText(customer.houseNumber + " " + customer.street)
+                   setIcon(com.sap.cloud.mobile.fiori.compose.R.drawable.ic_map_marker_unselected)
+               }
 
-                val cell4 = ActionCell(this@CustomersFioriMapActivity)
-                cell4.apply {
-                    setText("Additional Details")
-                    setIcon(com.sap.cloud.mobile.fiori.compose.R.drawable.ic_list_24dp)
-                    setOnClickListener{
-                        val intent = Intent(this@CustomersFioriMapActivity, ODataActivity::class.java)
-                        intent.putExtra("customer", customer)
-                        startActivity(intent)
-                    }
-                }
+               val cell4 = ActionCell(this@CustomersFioriMapActivity)
+               cell4.apply {
+                   setText("Additional Details")
+                   setIcon(com.sap.cloud.mobile.fiori.compose.R.drawable.ic_list_24dp)
+                   setOnClickListener{
+                       val intent = Intent(this@CustomersFioriMapActivity, ODataActivity::class.java)
+                       intent.putExtra("customer", customer)
+                       startActivity(intent)
+                   }
+               }
 
-                mapPreviewPanel.setActionCells(cell, cell2, cell3, cell4)
-            }
-        }
-        mActionProvider.annotationInfoAdapter = infoAdapter
-    }
+               mapPreviewPanel.setActionCells(cell, cell2, cell3, cell4)
+           }
+       }
+       mActionProvider.annotationInfoAdapter = infoAdapter
+   }
 
-    private fun setListAdapter() {
-        val mMapListPanel = mGoogleFioriMapView.mapListPanel
-        mMapResultsAdapter = MapResultsAdapter()
-        mMapListPanel.setAdapter(mMapResultsAdapter)
-    }
+   private fun setListAdapter() {
+       val mMapListPanel = mGoogleFioriMapView.mapListPanel
+       mMapResultsAdapter = MapResultsAdapter()
+       mMapListPanel.setAdapter(mMapResultsAdapter)
+   }
 
-    class ViewHolder(itemView: View): RecyclerView.ViewHolder(itemView) {
-        lateinit var objectCell: ObjectCell
-        init{
-            if (itemView is ObjectCell) {
-                objectCell = itemView
-            }
-        }
-    }
+   class ViewHolder(itemView: View): RecyclerView.ViewHolder(itemView) {
+       lateinit var objectCell: ObjectCell
+       init{
+           if (itemView is ObjectCell) {
+               objectCell = itemView
+           }
+       }
+   }
 
-    inner class MapResultsAdapter: RecyclerView.Adapter<ViewHolder>(), MapListPanel.MapListAdapter {
-        val customers = arrayListOf<Customer>()
+   inner class MapResultsAdapter: RecyclerView.Adapter<ViewHolder>(), MapListPanel.MapListAdapter {
+       val customers = arrayListOf<Customer>()
 
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) : ViewHolder {
-            val cell = ObjectCell(parent.context)
-            cell.preserveIconStackSpacing = true
-            cell.preserveDetailImageSpacing = false
-            return ViewHolder(cell)
-        }
+       override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) : ViewHolder {
+           val cell = ObjectCell(parent.context)
+           cell.preserveIconStackSpacing = true
+           cell.preserveDetailImageSpacing = false
+           return ViewHolder(cell)
+       }
 
-        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-            val customer = customers[position]
-            val resultCell = holder.objectCell
-            resultCell.apply {
-                headline = customer.firstName + " " + customer.lastName
-                subheadline = customer.houseNumber + " " + customer.street + ", " + customer.city
-                setStatus(customer.country, 1)
-                setOnClickListener{
-                    val intent = Intent(this@CustomersFioriMapActivity, ODataActivity::class.java)
-                    intent.putExtra("customer", customer)
-                    startActivity(intent)
-                }
-            }
-        }
+       override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+           val customer = customers[position]
+           val resultCell = holder.objectCell
+           resultCell.apply {
+               headline = customer.firstName + " " + customer.lastName
+               subheadline = customer.houseNumber + " " + customer.street + ", " + customer.city
+               setStatus(customer.country, 1)
+               setOnClickListener{
+                   val intent = Intent(this@CustomersFioriMapActivity, ODataActivity::class.java)
+                   intent.putExtra("customer", customer)
+                   startActivity(intent)
+               }
+           }
+       }
 
-        override fun getItemCount(): Int {
-            return customers.size
-        }
+       override fun getItemCount(): Int {
+           return customers.size
+       }
 
-        override fun clusterSelected(list: List<FioriMarkerOptions>?) {
-            customers.clear()
-            list?.let { l ->
-                for (fmo in l) {
-                    fmo.tag?.let {
-                        customers.add(it as Customer)
-                    }
-                }
-            }
-        }
-    }
-    ```
+       override fun clusterSelected(list: List<FioriMarkerOptions>?) {
+           customers.clear()
+           list?.let { l ->
+               for (fmo in l) {
+                   fmo.tag?.let {
+                       customers.add(it as Customer)
+                   }
+               }
+           }
+       }
+   }
+   ```
 
 4.  On Windows, press **`Ctrl+F12`**, or, on a Mac, press **`command+F12`**, and search for **`onMapCreated`**.
 
 5.  At the top of the method, below the line that sets `mActionProvider`, add the following code:
 
-    ```Kotlin
-    setupInfoProvider()
-    setListAdapter()
-    ```
+   ```Kotlin
+   setupInfoProvider()
+   setListAdapter()
+   ```
 
 6.  In the same method, comment out the following code. This will disable the default content panel so that the panel can be populated by the new methods.
 
-    ```Kotlin
-    val detailView = inflater.inflate(R.layout.detail_panel, null)
-    mGoogleFioriMapView.setDefaultPanelContent(detailView)
-    ```
+   ```Kotlin
+   val detailView = inflater.inflate(R.layout.detail_panel, null)
+   mGoogleFioriMapView.setDefaultPanelContent(detailView)
+   ```
 
 7.  On Windows, press **`Ctrl+N`**, or on a Mac, press **`command+O`**, and type **`CustomerODataViewModel`** to open `CustomerODataViewModel.kt`.
 
 8.  Add the companion object into the class:
 
-    ```Kotlin
-    companion object {
-        internal var selectedCustomerEntity: Customer? = null
-    }
-    ```
+   ```Kotlin
+   companion object {
+       internal var selectedCustomerEntity: Customer? = null
+   }
+   ```
 
 9.  On Windows, press **`Ctrl+N`**, or on a Mac, press **`command+O`**, and type **`ODataActivity`** to open `ODataActivity.kt`.
 
 10. Before calling function `ODataApp`, add the following code to get the selected customer.
 
-    ```Kotlin
-    val entity: Customer? = intent.extras?.let {
-        if (it.containsKey("customer")) {
-            it.get("customer") as Customer
-        } else {
-            null
-        }
-    }
-    CustomerODataViewModel.selectedCustomerEntity = entity
-    ```
+   ```Kotlin
+   val entity: Customer? = intent.extras?.let {
+       if (it.containsKey("customer")) {
+           it.get("customer") as Customer
+       } else {
+           null
+       }
+   }
+   CustomerODataViewModel.selectedCustomerEntity = entity
+   ```
 
 11. On Windows, press **`Ctrl+Shift+N`**, or on a Mac, press **`command+shift+O`**, and type **`ODataNavHost`** to open `ODataNavHost.kt`.
 
 12. Add the following code to the bottom of the function `ODataNavHost`:
 
-    ```Kotlin
-    CustomerODataViewModel.selectedCustomerEntity?.let {
-        val customer = EntityScreenInfo.Customers.entityType
-        navController.navigateToEntityList(customer)
-    }
-    ```
+   ```Kotlin
+   CustomerODataViewModel.selectedCustomerEntity?.let {
+       val customer = EntityScreenInfo.Customers.entityType
+       navController.navigateToEntityList(customer)
+   }
+   ```
 
 13. On Windows, press **`Ctrl+Shift+N`**, or on a Mac, press **`command+shift+O`**, and type **`CustomersMapScreen`** to open `CustomersMapScreen.kt`.
 
 14. Add the following code to the top of the body of `CustomersMapScreen`:
 
-    ```Kotlin
-    CustomerODataViewModel.selectedCustomerEntity?.let {
-        viewModel.onClickAction(it)
-        return@let
-    }
-    ```
+   ```Kotlin
+   CustomerODataViewModel.selectedCustomerEntity?.let {
+       viewModel.onClickAction(it)
+       return@let
+   }
+   ```
 
 15. On Windows, press **`Ctrl+Shift+N`**, or on a Mac, press **`command+shift+O`**, and type **`CustomerEntityDetailScreen`** to open `CustomerEntityDetailScreen.kt`.
 
 16. Declare a context variable right before `OperationScreen(`:
 
-    ```Kotlin
-    val context = LocalContext.current
-    ```
+   ```Kotlin
+   val context = LocalContext.current
+   ```
 
 17. On Windows, press **`Ctrl+F`**, or on a Mac, press **`command+F`**, and search for **`navigateUp = if (isExpandedScreen)`**.
 
 18. Replace it with the following so we can navigate back from the customer detail screen to the fiori map screen:
 
-    ```Kotlin
-    navigateUp = if (isExpandedScreen) {
-                null
-            } else if (CustomerODataViewModel.selectedCustomerEntity != null) {
-                {
-                    context.startActivity(Intent(context, CustomersFioriMapActivity::class.java))
-                }
-            } else {
-                navigateUp
-            },
-    ```
+   ```Kotlin
+   navigateUp = if (isExpandedScreen) {
+               null
+           } else if (CustomerODataViewModel.selectedCustomerEntity != null) {
+               {
+                   context.startActivity(Intent(context, CustomersFioriMapActivity::class.java))
+               }
+           } else {
+               navigateUp
+           },
+   ```
 
 19. Run the app.
 
@@ -1664,138 +1664,138 @@ In this section, the bottom panel will be populated with details of the selected
 
 2.  At the top of the class, add the following variables:
 
-    ```Kotlin
-    private lateinit var mMapResultsAdapter: MapResultsAdapter
-    ```
+   ```Kotlin
+   private lateinit var mMapResultsAdapter: MapResultsAdapter
+   ```
 
 3.  At the bottom of the class, add the following methods and the `MapResultsAdapter` class.
 
-    ```Kotlin
-    private fun setupInfoProvider() {
-        val infoAdapter = object:AnnotationInfoAdapter {
-            override fun getInfo(tag: Any) : Any {
-                return tag
-            }
+   ```Kotlin
+   private fun setupInfoProvider() {
+       val infoAdapter = object:AnnotationInfoAdapter {
+           override fun getInfo(tag: Any) : Any {
+               return tag
+           }
 
-            override fun onBindView(mapPreviewPanel: MapPreviewPanel, info: Any) {
-                val customer = info as Customer
-                mapPreviewPanel.setTitle(customer.firstName + " " + customer.lastName)
+           override fun onBindView(mapPreviewPanel: MapPreviewPanel, info: Any) {
+               val customer = info as Customer
+               mapPreviewPanel.setTitle(customer.firstName + " " + customer.lastName)
 
-                val objectHeader = mapPreviewPanel.objectHeader
-                objectHeader.apply {
-                    headline = customer.city + ", " + customer.country
-                    val customerLatLng = getCustomerLatLongFromAddress(customer.city + ", " + customer.country)
-                    customerLatLng?.let {
-                        body = "Latitude: " + it.latitude
-                        footnote = "Longitude " + it.longitude
-                    }
-                }
+               val objectHeader = mapPreviewPanel.objectHeader
+               objectHeader.apply {
+                   headline = customer.city + ", " + customer.country
+                   val customerLatLng = getCustomerLatLongFromAddress(customer.city + ", " + customer.country)
+                   customerLatLng?.let {
+                       body = "Latitude: " + it.latitude
+                       footnote = "Longitude " + it.longitude
+                   }
+               }
 
-                val cell = ActionCell(this@CustomersFioriMapActivity)
-                cell.apply {
-                    setText(customer.phoneNumber)
-                    setIcon(R.drawable.ic_phone_black_24dp)
-                }
+               val cell = ActionCell(this@CustomersFioriMapActivity)
+               cell.apply {
+                   setText(customer.phoneNumber)
+                   setIcon(R.drawable.ic_phone_black_24dp)
+               }
 
-                val cell2 = ActionCell(this@CustomersFioriMapActivity)
-                cell2.apply {
-                    setText(customer.emailAddress)
-                    setIcon(R.drawable.ic_email_black_24dp)
-                }
+               val cell2 = ActionCell(this@CustomersFioriMapActivity)
+               cell2.apply {
+                   setText(customer.emailAddress)
+                   setIcon(R.drawable.ic_email_black_24dp)
+               }
 
-                val cell3 = ActionCell(this@CustomersFioriMapActivity)
-                cell3.apply {
-                    setText(customer.houseNumber + " " + customer.street)
-                    setIcon(R.drawable.ic_map_marker_unselected)
-                }
+               val cell3 = ActionCell(this@CustomersFioriMapActivity)
+               cell3.apply {
+                   setText(customer.houseNumber + " " + customer.street)
+                   setIcon(R.drawable.ic_map_marker_unselected)
+               }
 
-                val cell4 = ActionCell(this@CustomersFioriMapActivity)
-                cell4.apply {
-                    setText("Additional Details")
-                    setIcon(R.drawable.ic_list_24dp)
-                    setOnClickListener{ v ->
-                        val intent = Intent(this@CustomersFioriMapActivity, CustomersActivity::class.java)
-                        intent.putExtra(BundleKeys.ENTITY_INSTANCE, customer)
-                        startActivity(intent) }
-                }
+               val cell4 = ActionCell(this@CustomersFioriMapActivity)
+               cell4.apply {
+                   setText("Additional Details")
+                   setIcon(R.drawable.ic_list_24dp)
+                   setOnClickListener{ v ->
+                       val intent = Intent(this@CustomersFioriMapActivity, CustomersActivity::class.java)
+                       intent.putExtra(BundleKeys.ENTITY_INSTANCE, customer)
+                       startActivity(intent) }
+               }
 
-                mapPreviewPanel.setActionCells(cell, cell2, cell3, cell4)
-            }
-        }
-        mActionProvider.annotationInfoAdapter = infoAdapter
-    }
+               mapPreviewPanel.setActionCells(cell, cell2, cell3, cell4)
+           }
+       }
+       mActionProvider.annotationInfoAdapter = infoAdapter
+   }
 
-    private fun setListAdapter() {
-            val mMapListPanel = mGoogleFioriMapView.mapListPanel
-            mMapResultsAdapter = MapResultsAdapter()
-            mMapListPanel.setAdapter(mMapResultsAdapter)
-    }
+   private fun setListAdapter() {
+           val mMapListPanel = mGoogleFioriMapView.mapListPanel
+           mMapResultsAdapter = MapResultsAdapter()
+           mMapListPanel.setAdapter(mMapResultsAdapter)
+   }
 
-    class ViewHolder(itemView: View): RecyclerView.ViewHolder(itemView) {
-        lateinit var objectCell: ObjectCell
-        init{
-            if (itemView is ObjectCell) {
-                objectCell = itemView
-            }
-        }
-    }
+   class ViewHolder(itemView: View): RecyclerView.ViewHolder(itemView) {
+       lateinit var objectCell: ObjectCell
+       init{
+           if (itemView is ObjectCell) {
+               objectCell = itemView
+           }
+       }
+   }
 
-    inner class MapResultsAdapter: RecyclerView.Adapter<ViewHolder>(), MapListPanel.MapListAdapter {
-        val customers = arrayListOf<Customer>()
+   inner class MapResultsAdapter: RecyclerView.Adapter<ViewHolder>(), MapListPanel.MapListAdapter {
+       val customers = arrayListOf<Customer>()
 
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) : ViewHolder {
-            val cell = ObjectCell(parent.context)
-            cell.preserveIconStackSpacing = true
-            cell.preserveDetailImageSpacing = false
-            return ViewHolder(cell)
-        }
+       override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) : ViewHolder {
+           val cell = ObjectCell(parent.context)
+           cell.preserveIconStackSpacing = true
+           cell.preserveDetailImageSpacing = false
+           return ViewHolder(cell)
+       }
 
-        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-            val customer = customers[position]
-            val resultCell = holder.objectCell
-            resultCell.apply {
-                headline = customer.firstName + " " + customer.lastName
-                subheadline = customer.houseNumber + " " + customer.street + ", " + customer.city
-                setStatus(customer.country, 1)
-                setOnClickListener{ v->
-                    val intent = Intent(this@CustomersFioriMapActivity, CustomersActivity::class.java)
-                    intent.putExtra(BundleKeys.ENTITY_INSTANCE, customer)
-                    startActivity(intent) }
-            }
-        }
+       override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+           val customer = customers[position]
+           val resultCell = holder.objectCell
+           resultCell.apply {
+               headline = customer.firstName + " " + customer.lastName
+               subheadline = customer.houseNumber + " " + customer.street + ", " + customer.city
+               setStatus(customer.country, 1)
+               setOnClickListener{ v->
+                   val intent = Intent(this@CustomersFioriMapActivity, CustomersActivity::class.java)
+                   intent.putExtra(BundleKeys.ENTITY_INSTANCE, customer)
+                   startActivity(intent) }
+           }
+       }
 
-        override fun getItemCount(): Int {
-            return customers.size
-        }
+       override fun getItemCount(): Int {
+           return customers.size
+       }
 
-        override fun clusterSelected(list: List<FioriMarkerOptions>?) {
-            customers.clear()
-            list?.let { l ->
-                for (fmo in l) {
-                    fmo.tag?.let {
-                        customers.add(it as Customer)
-                    }
-                }
-            }
-        }
-    }
-    ```
+       override fun clusterSelected(list: List<FioriMarkerOptions>?) {
+           customers.clear()
+           list?.let { l ->
+               for (fmo in l) {
+                   fmo.tag?.let {
+                       customers.add(it as Customer)
+                   }
+               }
+           }
+       }
+   }
+   ```
 
 4.  On Windows, press **`Ctrl+F12`**, or, on a Mac, press **`command+F12`**, and search for **`onMapCreated`**.
 
 5.  At the top of the method, below the line that sets `mActionProvider`, add the following code:
 
-    ```Kotlin
-    setupInfoProvider()
-    setListAdapter()
-    ```
+   ```Kotlin
+   setupInfoProvider()
+   setListAdapter()
+   ```
 
 6.  In the same method, comment out the following code. This will disable the default content panel so that the panel can be populated by the new methods.
 
-    ```Kotlin
-    val detailView = inflater.inflate(R.layout.detail_panel, null)
-    mGoogleFioriMapView.setDefaultPanelContent(detailView)
-    ```
+   ```Kotlin
+   val detailView = inflater.inflate(R.layout.detail_panel, null)
+   mGoogleFioriMapView.setDefaultPanelContent(detailView)
+   ```
 
 7.  Run the app.
 
@@ -1821,43 +1821,43 @@ In this section you will implement the settings dialog to include a map type set
 
 1.  Create a new **Layout Resource File** in `app/src/main/res/layout` called **`settings_panel.xml`** and replace its contents with the following code. This creates the layout for the settings page.
 
-    ```XML
-    <?xml version="1.0" encoding="utf-8"?>
-    <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+   ```XML
+   <?xml version="1.0" encoding="utf-8"?>
+   <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:app="http://schemas.android.com/apk/res-auto"
+       android:layout_width="match_parent"
+       android:layout_height="match_parent">
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
+       <LinearLayout
+           android:layout_width="match_parent"
+           android:layout_height="wrap_content"
+           android:orientation="vertical">
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_gravity="fill_horizontal"
-                android:orientation="horizontal">
+           <LinearLayout
+               android:layout_width="match_parent"
+               android:layout_height="wrap_content"
+               android:layout_gravity="fill_horizontal"
+               android:orientation="horizontal">
 
-                <com.sap.cloud.mobile.fiori.formcell.ChoiceFormCell
-                    android:id="@+id/map_type"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:key="Map Type" />
+               <com.sap.cloud.mobile.fiori.formcell.ChoiceFormCell
+                   android:id="@+id/map_type"
+                   android:layout_width="match_parent"
+                   android:layout_height="wrap_content"
+                   app:key="Map Type" />
 
-            </LinearLayout>
+           </LinearLayout>
 
-            <com.sap.cloud.mobile.fiori.formcell.SwitchFormCell
-                android:id="@+id/use_clustering"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:showText="true"
-                app:key="Clustering"
-                app:value="true" />
+           <com.sap.cloud.mobile.fiori.formcell.SwitchFormCell
+               android:id="@+id/use_clustering"
+               android:layout_width="match_parent"
+               android:layout_height="wrap_content"
+               android:showText="true"
+               app:key="Clustering"
+               app:value="true" />
 
-        </LinearLayout>
-    </ScrollView>
-    ```
+       </LinearLayout>
+   </ScrollView>
+   ```
 
 2.  On Windows, press **`Ctrl+N`**, or, on a Mac, press **`command+O`**, and type **`CustomersFioriMapActivity`** to open `CustomersFioriMapActivity.kt`.
 
@@ -1865,57 +1865,57 @@ In this section you will implement the settings dialog to include a map type set
 
 4.  Find the following line of code:
 
-    ```Kotlin
-    mActionProvider.setClustering(false)
-    ```
+   ```Kotlin
+   mActionProvider.setClustering(false)
+   ```
 
 5.  Replace the line above with the following code:
 
-    ```Kotlin
-    val settingsView = inflater.inflate(R.layout.settings_panel, null)
+   ```Kotlin
+   val settingsView = inflater.inflate(R.layout.settings_panel, null)
 
-    // Setup selection of a different map type
-    val mapTypeChoice = settingsView.findViewById<ChoiceFormCell>(R.id.map_type)
-    mapTypeChoice.valueOptions = arrayOf<String>("Normal", "Satellite", "Terrain", "Hybrid")
-    mapTypeChoice.cellValueChangeListener = object : FormCell.CellValueChangeListener<Int>() {
-        override fun cellChangeHandler(value: Int?) {
-            value?.let {
-                when (it) {
-                    0 -> mMapType = GoogleMap.MAP_TYPE_NORMAL
-                    1 -> mMapType = GoogleMap.MAP_TYPE_SATELLITE
-                    2 -> mMapType = GoogleMap.MAP_TYPE_TERRAIN
-                    3 -> mMapType = GoogleMap.MAP_TYPE_HYBRID
-                }
-                mGoogleFioriMapView.map?.mapType = mMapType
-            }
-        }
-    }
+   // Setup selection of a different map type
+   val mapTypeChoice = settingsView.findViewById<ChoiceFormCell>(R.id.map_type)
+   mapTypeChoice.valueOptions = arrayOf<String>("Normal", "Satellite", "Terrain", "Hybrid")
+   mapTypeChoice.cellValueChangeListener = object : FormCell.CellValueChangeListener<Int>() {
+       override fun cellChangeHandler(value: Int?) {
+           value?.let {
+               when (it) {
+                   0 -> mMapType = GoogleMap.MAP_TYPE_NORMAL
+                   1 -> mMapType = GoogleMap.MAP_TYPE_SATELLITE
+                   2 -> mMapType = GoogleMap.MAP_TYPE_TERRAIN
+                   3 -> mMapType = GoogleMap.MAP_TYPE_HYBRID
+               }
+               mGoogleFioriMapView.map?.mapType = mMapType
+           }
+       }
+   }
 
-    if (mMapType == 0) {
-        mapTypeChoice.value = mMapType
-    } else {
-        mapTypeChoice.value = mMapType - 1
-    }
+   if (mMapType == 0) {
+       mapTypeChoice.value = mMapType
+   } else {
+       mapTypeChoice.value = mMapType - 1
+   }
 
-    mGoogleFioriMapView.setSettingsView(settingsView)
+   mGoogleFioriMapView.setSettingsView(settingsView)
 
-    if (mMapType != GoogleMap.MAP_TYPE_NONE) {
-        mGoogleFioriMapView.map?.mapType = mMapType
-    }
+   if (mMapType != GoogleMap.MAP_TYPE_NONE) {
+       mGoogleFioriMapView.map?.mapType = mMapType
+   }
 
-    // Setup clustering selection.
-    val useClusteringSwitch = settingsView.findViewById<SwitchFormCell>(R.id.use_clustering)
-    useClusteringSwitch.value = mUseClustering
-    mActionProvider.setClustering(mUseClustering)
-    useClusteringSwitch.cellValueChangeListener = object: FormCell.CellValueChangeListener<Boolean>() {
-        override fun cellChangeHandler(value: Boolean?) {
-            value?.let {
-                mUseClustering = it
-                mActionProvider.setClustering(mUseClustering)
-            }
-        }
-    }
-    ```
+   // Setup clustering selection.
+   val useClusteringSwitch = settingsView.findViewById<SwitchFormCell>(R.id.use_clustering)
+   useClusteringSwitch.value = mUseClustering
+   mActionProvider.setClustering(mUseClustering)
+   useClusteringSwitch.cellValueChangeListener = object: FormCell.CellValueChangeListener<Boolean>() {
+       override fun cellChangeHandler(value: Boolean?) {
+           value?.let {
+               mUseClustering = it
+               mActionProvider.setClustering(mUseClustering)
+           }
+       }
+   }
+   ```
 
 6.  Run the app.
 
@@ -1949,58 +1949,58 @@ In this section, you will test the three different types of annotations.
 
 3. Add the following code after the `mGoogleFioriMapView.onCreate` is called. This will save any points, polylines, or polygons drawn on the map.
 
-    ```Kotlin
-    // Handle the editor's save event.
-    // This is where you can implement functions to save the new annotated points, polylines, and polygons
-    mGoogleFioriMapView.editorView.setOnSaveListener{annotation ->
-        var message: String? = null
-        when (annotation) {
-            is PointAnnotation -> {
-                message = "This is a point"
-            }
-            is PolylineAnnotation -> {
-                message = "This is a polyline with " + annotation.points.size + " points"
-            }
-            is PolygonAnnotation -> {
-                message = "This is a polygon with " + annotation.points.size + " points"
-            }
-        }
+   ```Kotlin
+   // Handle the editor's save event.
+   // This is where you can implement functions to save the new annotated points, polylines, and polygons
+   mGoogleFioriMapView.editorView.setOnSaveListener{annotation ->
+       var message: String? = null
+       when (annotation) {
+           is PointAnnotation -> {
+               message = "This is a point"
+           }
+           is PolylineAnnotation -> {
+               message = "This is a polyline with " + annotation.points.size + " points"
+           }
+           is PolygonAnnotation -> {
+               message = "This is a polygon with " + annotation.points.size + " points"
+           }
+       }
 
-        // import android.app AlertDialog
-        val builder = AlertDialog.Builder(mGoogleFioriMapView.context, com.sap.cloud.mobile.fiori.R.style.FioriAlertDialogStyle)
-        builder.setMessage(message)
-        builder.setPositiveButton("Save") { _, _ ->
-            // Close the editor.
-            mGoogleFioriMapView.isEditable = false
-            when (annotation) {
-                is PointAnnotation -> {
-                    mActionProvider.addCircle(
-                        FioriCircleOptions.Builder().center(annotation.points[0] as FioriPoint).radius(40.0).strokeColor(resources.getColor(
-                            com.sap.cloud.mobile.fiori.maps.google.R.color.maps_marker_color_5 , null)).fillColor(resources.getColor(com.sap.cloud.mobile.fiori.maps.google.R.color.maps_marker_color_6, null)).title("Editor Circle").build())
-                }
-                is PolylineAnnotation -> {
-                    mActionProvider.addPolyline(
-                        FioriPolylineOptions.Builder().addAll(annotation.points as Iterable<FioriPoint>).color(resources.getColor(com.sap.cloud.mobile.fiori.maps.google.R.color.maps_marker_color_3, null)).strokeWidth(4f).title("Editor Polyline").build())
-                }
-                is PolygonAnnotation -> {
-                    mActionProvider.addPolygon(
-                        FioriPolygonOptions.Builder().addAll(annotation.points as Iterable<FioriPoint>).strokeColor(resources.getColor(com.sap.cloud.mobile.fiori.maps.google.R.color.maps_marker_color_3, null)).fillColor(resources.getColor(com.sap.cloud.mobile.fiori.maps.google.R.color.maps_marker_color_4, null)).strokeWidth(4f).title("Editor Polygon").build())
-                }
-            }
-        }
-        builder.setNegativeButton("Cancel") { dialogInterface, _ -> dialogInterface.cancel() }
-        val dialog = builder.create()
-        dialog.show()
-    }
-    ```
+       // import android.app AlertDialog
+       val builder = AlertDialog.Builder(mGoogleFioriMapView.context, com.sap.cloud.mobile.fiori.R.style.FioriAlertDialogStyle)
+       builder.setMessage(message)
+       builder.setPositiveButton("Save") { _, _ ->
+           // Close the editor.
+           mGoogleFioriMapView.isEditable = false
+           when (annotation) {
+               is PointAnnotation -> {
+                   mActionProvider.addCircle(
+                       FioriCircleOptions.Builder().center(annotation.points[0] as FioriPoint).radius(40.0).strokeColor(resources.getColor(
+                           com.sap.cloud.mobile.fiori.maps.google.R.color.maps_marker_color_5 , null)).fillColor(resources.getColor(com.sap.cloud.mobile.fiori.maps.google.R.color.maps_marker_color_6, null)).title("Editor Circle").build())
+               }
+               is PolylineAnnotation -> {
+                   mActionProvider.addPolyline(
+                       FioriPolylineOptions.Builder().addAll(annotation.points as Iterable<FioriPoint>).color(resources.getColor(com.sap.cloud.mobile.fiori.maps.google.R.color.maps_marker_color_3, null)).strokeWidth(4f).title("Editor Polyline").build())
+               }
+               is PolygonAnnotation -> {
+                   mActionProvider.addPolygon(
+                       FioriPolygonOptions.Builder().addAll(annotation.points as Iterable<FioriPoint>).strokeColor(resources.getColor(com.sap.cloud.mobile.fiori.maps.google.R.color.maps_marker_color_3, null)).fillColor(resources.getColor(com.sap.cloud.mobile.fiori.maps.google.R.color.maps_marker_color_4, null)).strokeWidth(4f).title("Editor Polygon").build())
+               }
+           }
+       }
+       builder.setNegativeButton("Cancel") { dialogInterface, _ -> dialogInterface.cancel() }
+       val dialog = builder.create()
+       dialog.show()
+   }
+   ```
 
 4. Add the following code in the app module's `build.gradle` file in the `configurations.configureEach` block and click **Sync Now**.
 
-    ```Gradle
-    resolutionStrategy {
-        force("com.google.android.gms:play-services-location:21.3.0")
-    }
-    ```
+   ```Gradle
+   resolutionStrategy {
+       force("com.google.android.gms:play-services-location:21.3.0")
+   }
+   ```
 
 5. Run the app.
 
@@ -2055,14 +2055,14 @@ In this section, you will test the three different types of annotations.
     ![Google Cloud Platform Places API page](places-api.png)
 
     > If you enabled **Places API** but still nothing happens after tapping, use
-    ```URL
-    https://maps.googleapis.com/maps/api/place/details/json?place_id=ChIJN1t_tDeuEmsRUsoyG83frY4&fields=name,rating,formatted_phone_number&key=YOUR_API_KEY
-    ```
-    to see if your application could get certain place details successfully. Note that you'll need to replace the key in this example with your own API key. See [Google Maps Platform](https://developers.google.com/places/web-service/details#PlaceDetailsStatusCodes) for additional information.
+   ```URL
+   https://maps.googleapis.com/maps/api/place/details/json?place_id=ChIJN1t_tDeuEmsRUsoyG83frY4&fields=name,rating,formatted_phone_number&key=YOUR_API_KEY
+   ```
+   to see if your application could get certain place details successfully. Note that you'll need to replace the key in this example with your own API key. See [Google Maps Platform](https://developers.google.com/places/web-service/details#PlaceDetailsStatusCodes) for additional information.
 
-    You can also add a point by tapping directly on the map. This will create a white and blue dot indicating where the new point is located. The added point will appear in the panel under the **Address** section. You can only add one point to the map. You can move it by long pressing on it and then dragging it to a new location or you can delete it (select the point and then click the **X** mark in the **ADDRESS** list) and then add a new point.
+   You can also add a point by tapping directly on the map. This will create a white and blue dot indicating where the new point is located. The added point will appear in the panel under the **Address** section. You can only add one point to the map. You can move it by long pressing on it and then dragging it to a new location or you can delete it (select the point and then click the **X** mark in the **ADDRESS** list) and then add a new point.
 
-    ![Point added onto map](added-point.png)
+   ![Point added onto map](added-point.png)
 
 14. To add a polyline to the map, select the **Polyline** option and tap different places on the map to add multiple points. The added points will be connected with a line.
 
@@ -2084,57 +2084,57 @@ In this section, you will test the three different types of annotations.
 
 3. Add the following code after the `mGoogleFioriMapView.onCreate` is called. This will save any points, polylines, or polygons drawn on the map.
 
-    ```Kotlin
-    // Handle the editor's save event.
-    // This is where you can implement functions to save the new annotated points, polylines, and polygons
-    mGoogleFioriMapView.editorView.setOnSaveListener{annotation ->
-        var message: String? = null
-        when (annotation) {
-            is PointAnnotation -> {
-                message = "This is a point"
-            }
-            is PolylineAnnotation -> {
-                message = "This is a polyline with " + annotation.points.size + " points"
-            }
-            is PolygonAnnotation -> {
-                message = "This is a polygon with " + annotation.points.size + " points"
-            }
-        }
+   ```Kotlin
+   // Handle the editor's save event.
+   // This is where you can implement functions to save the new annotated points, polylines, and polygons
+   mGoogleFioriMapView.editorView.setOnSaveListener{annotation ->
+       var message: String? = null
+       when (annotation) {
+           is PointAnnotation -> {
+               message = "This is a point"
+           }
+           is PolylineAnnotation -> {
+               message = "This is a polyline with " + annotation.points.size + " points"
+           }
+           is PolygonAnnotation -> {
+               message = "This is a polygon with " + annotation.points.size + " points"
+           }
+       }
 
-        // import android.app AlertDialog
-        val builder = AlertDialog.Builder(mGoogleFioriMapView.context, com.sap.cloud.mobile.fiori.R.style.FioriAlertDialogStyle)
-        builder.setMessage(message)
-        builder.setPositiveButton("Save") { _, _ ->
-            // Close the editor.
-            mGoogleFioriMapView.isEditable = false
-            when (annotation) {
-                is PointAnnotation -> {
-                    mActionProvider.addCircle(
-                            FioriCircleOptions.Builder().center(annotation.points[0] as FioriPoint).radius(40.0).strokeColor(resources.getColor(R.color.maps_marker_color_5, null)).fillColor(resources.getColor(R.color.maps_marker_color_6, null)).title("Editor Circle").build())
-                }
-                is PolylineAnnotation -> {
-                    mActionProvider.addPolyline(
-                            FioriPolylineOptions.Builder().addAll(annotation.points as Iterable<FioriPoint>).color(resources.getColor(R.color.maps_marker_color_3, null)).strokeWidth(4f).title("Editor Polyline").build())
-                }
-                is PolygonAnnotation -> {
-                    mActionProvider.addPolygon(
-                            FioriPolygonOptions.Builder().addAll(annotation.points as Iterable<FioriPoint>).strokeColor(resources.getColor(R.color.maps_marker_color_3, null)).fillColor(resources.getColor(R.color.maps_marker_color_4, null)).strokeWidth(4f).title("Editor Polygon").build())
-                }
-            }
-        }
-        builder.setNegativeButton("Cancel") { dialogInterface, _ -> dialogInterface.cancel() }
-        val dialog = builder.create()
-        dialog.show()
-    }
-    ```
+       // import android.app AlertDialog
+       val builder = AlertDialog.Builder(mGoogleFioriMapView.context, com.sap.cloud.mobile.fiori.R.style.FioriAlertDialogStyle)
+       builder.setMessage(message)
+       builder.setPositiveButton("Save") { _, _ ->
+           // Close the editor.
+           mGoogleFioriMapView.isEditable = false
+           when (annotation) {
+               is PointAnnotation -> {
+                   mActionProvider.addCircle(
+                           FioriCircleOptions.Builder().center(annotation.points[0] as FioriPoint).radius(40.0).strokeColor(resources.getColor(R.color.maps_marker_color_5, null)).fillColor(resources.getColor(R.color.maps_marker_color_6, null)).title("Editor Circle").build())
+               }
+               is PolylineAnnotation -> {
+                   mActionProvider.addPolyline(
+                           FioriPolylineOptions.Builder().addAll(annotation.points as Iterable<FioriPoint>).color(resources.getColor(R.color.maps_marker_color_3, null)).strokeWidth(4f).title("Editor Polyline").build())
+               }
+               is PolygonAnnotation -> {
+                   mActionProvider.addPolygon(
+                           FioriPolygonOptions.Builder().addAll(annotation.points as Iterable<FioriPoint>).strokeColor(resources.getColor(R.color.maps_marker_color_3, null)).fillColor(resources.getColor(R.color.maps_marker_color_4, null)).strokeWidth(4f).title("Editor Polygon").build())
+               }
+           }
+       }
+       builder.setNegativeButton("Cancel") { dialogInterface, _ -> dialogInterface.cancel() }
+       val dialog = builder.create()
+       dialog.show()
+   }
+   ```
 
 4. Add the following code in the app module's `build.gradle` file in the `configurations.all` block and click **Sync Now**.
 
-    ```Gradle
-    resolutionStrategy {
-        force("com.google.android.gms:play-services-location:21.3.0")
-    }
-    ```
+   ```Gradle
+   resolutionStrategy {
+       force("com.google.android.gms:play-services-location:21.3.0")
+   }
+   ```
 
     ![Force play-services-location version](force-play-services-location-version.png)
 
@@ -2191,14 +2191,14 @@ In this section, you will test the three different types of annotations.
     ![Google Cloud Platform Places API page](places-api.png)
 
     > If you enabled **Places API** but still nothing happens after tapping, use
-    ```URL
-    https://maps.googleapis.com/maps/api/place/details/json?place_id=ChIJN1t_tDeuEmsRUsoyG83frY4&fields=name,rating,formatted_phone_number&key=YOUR_API_KEY
-    ```
-    to see if your application could get certain place details successfully. Note that you'll need to replace the key in this example with your own API key. See [Google Maps Platform](https://developers.google.com/places/web-service/details#PlaceDetailsStatusCodes) for additional information.
+   ```URL
+   https://maps.googleapis.com/maps/api/place/details/json?place_id=ChIJN1t_tDeuEmsRUsoyG83frY4&fields=name,rating,formatted_phone_number&key=YOUR_API_KEY
+   ```
+   to see if your application could get certain place details successfully. Note that you'll need to replace the key in this example with your own API key. See [Google Maps Platform](https://developers.google.com/places/web-service/details#PlaceDetailsStatusCodes) for additional information.
 
-    You can also add a point by tapping directly on the map. This will create a white and blue dot indicating where the new point is located. The added point will appear in the panel under the **Address** section. You can only add one point to the map. You can move it by long pressing on it and then dragging it to a new location or you can delete it (select the point and then click the **X** mark in the **ADDRESS** list) and then add a new point.
+   You can also add a point by tapping directly on the map. This will create a white and blue dot indicating where the new point is located. The added point will appear in the panel under the **Address** section. You can only add one point to the map. You can move it by long pressing on it and then dragging it to a new location or you can delete it (select the point and then click the **X** mark in the **ADDRESS** list) and then add a new point.
 
-    ![Point added onto map](added-point.png)
+   ![Point added onto map](added-point.png)
 
 14. To add a polyline to the map, select the **Polyline** option and tap different places on the map to add multiple points. The added points will be connected with a line.
 
@@ -2226,29 +2226,29 @@ In this section you will customize the map markers based on the customer's count
 
 3.  Replace the method with the following code:
 
-    ```Kotlin
-    private fun addCustomerMarkerToMap(customer: Customer) {
-        val country = customer.country
-        getCustomerLatLongFromAddress(customer.city + ", " + country)?.let { latLng ->
-            var color = ("#E9573E".toColorInt()) // US
-            if (country == "MX") {
-                color = ("#FFA02B".toColorInt())
-            } else if (country == "CA") {
-                color = "#0070F2".toColorInt()
-            }
-            val customerMarker = FioriMarkerOptions.Builder()
-                .tag(customer)
-                .point(FioriPoint(latLng.latitude, latLng.longitude))
-                .title(customer.firstName + " " + customer.lastName)
-                .legendTitle(customer.country)
-                .color(color)
-                .build()
-            mActionProvider.addMarker(customerMarker)
-            markers[customer.city + ", " + customer.country] = customerMarker
-            mGoogleFioriMapView.map?.moveCamera(CameraUpdateFactory.newLatLng(latLng))
-        }
-    }
-    ```
+   ```Kotlin
+   private fun addCustomerMarkerToMap(customer: Customer) {
+       val country = customer.country
+       getCustomerLatLongFromAddress(customer.city + ", " + country)?.let { latLng ->
+           var color = ("#E9573E".toColorInt()) // US
+           if (country == "MX") {
+               color = ("#FFA02B".toColorInt())
+           } else if (country == "CA") {
+               color = "#0070F2".toColorInt()
+           }
+           val customerMarker = FioriMarkerOptions.Builder()
+               .tag(customer)
+               .point(FioriPoint(latLng.latitude, latLng.longitude))
+               .title(customer.firstName + " " + customer.lastName)
+               .legendTitle(customer.country)
+               .color(color)
+               .build()
+           mActionProvider.addMarker(customerMarker)
+           markers[customer.city + ", " + customer.country] = customerMarker
+           mGoogleFioriMapView.map?.moveCamera(CameraUpdateFactory.newLatLng(latLng))
+       }
+   }
+   ```
 
 4.  Run the app.
 

--- a/tutorials/sdk-android-wizard-app-multiuser/sdk-android-wizard-app-multiuser.md
+++ b/tutorials/sdk-android-wizard-app-multiuser/sdk-android-wizard-app-multiuser.md
@@ -79,12 +79,12 @@ The following cases are not supported in multi-user mode:
 
 3. On Windows, press **`Ctrl+F12`**, or on a Mac, press **`command+F12`**, and type **`startOnboarding`** to navigate to the `startOnboarding` method. For the `FlowContext` instance, change the parameter of the `setMultipleUserMode` method from `false` to **`true`**:
 
-    ```Kotlin
-    val flowContext =
-                FlowContextBuilder()
-                    .setApplication(appConfig)
-                    .setMultipleUserMode(true)
-    ```
+   ```Kotlin
+   val flowContext =
+               FlowContextBuilder()
+                   .setApplication(appConfig)
+                   .setMultipleUserMode(true)
+   ```
 
     Notice that the setting will only take effect when the very first user onboards. Once a user is onboarded, this setting will be saved in the local database. All subsequent flows will use the same setting from the database and ignore the one inside `flowContext`. To change this setting, you need to reset the application to bring up the onboarding process, and the new setting will be updated in the local database after onboarding.
 
@@ -124,67 +124,67 @@ The following cases are not supported in multi-user mode:
 
 5.  On Windows, press **`Ctrl+F12`**, or on a Mac, press **`command+F12`**, and type **`initializeOffline`** to navigate to the `initializeOffline` method. Notice that for the `OfflineODataParameters` instance, the value of the `isForceUploadOnUserSwitch` parameter is set based on the value of `runtimeMultipleUserMode`. This value is retrieved from the `UserSecureStoreDelegate.getInstance().getRuntimeMultipleUserMode()` API call in `OfflineOpenViewModel.kt`.
 
-    ```Kotlin
-    /*
-     * Create OfflineODataProvider
-     * This is a blocking call, no data will be transferred until open, download, upload
-     * @return if initialization needed
-     */
-    suspend fun initializeOffline(
-        context: Context,
-        appConfig: AppConfig,
-        runtimeMultipleUserMode: Boolean
-    ): Boolean {
-        ...
+   ```Kotlin
+   /*
+    * Create OfflineODataProvider
+    * This is a blocking call, no data will be transferred until open, download, upload
+    * @return if initialization needed
+    */
+   suspend fun initializeOffline(
+       context: Context,
+       appConfig: AppConfig,
+       runtimeMultipleUserMode: Boolean
+   ): Boolean {
+       ...
 
-        try {
-            val url = URL(serviceUrl + CONNECTION_ID_ESPMCONTAINER)
-            val offlineODataParameters = OfflineODataParameters().apply {
-                ...
+       try {
+           val url = URL(serviceUrl + CONNECTION_ID_ESPMCONTAINER)
+           val offlineODataParameters = OfflineODataParameters().apply {
+               ...
 
-                isForceUploadOnUserSwitch = runtimeMultipleUserMode
-                val encryptionKey = if (runtimeMultipleUserMode) {
-                    UserSecureStoreDelegate.getInstance().getOfflineEncryptionKey()
-                } else { //If is single user mode, create and save a key into user secure store for accessing offline DB
-                    ...
-                }
-                storeEncryptionKey = encryptionKey
-            }.also {
-                ...
-            }
-            logger.debug("start init offline odata provider")
-            
-            ...
+               isForceUploadOnUserSwitch = runtimeMultipleUserMode
+               val encryptionKey = if (runtimeMultipleUserMode) {
+                   UserSecureStoreDelegate.getInstance().getOfflineEncryptionKey()
+               } else { //If is single user mode, create and save a key into user secure store for accessing offline DB
+                   ...
+               }
+               storeEncryptionKey = encryptionKey
+           }.also {
+               ...
+           }
+           logger.debug("start init offline odata provider")
+           
+           ...
 
-            return true
-        } catch (e: Exception) {
-            logger.error("Exception encountered setting up offline store: " + e.message)
-            throw e
-        }
-    }
-    ```
+           return true
+       } catch (e: Exception) {
+           logger.error("Exception encountered setting up offline store: " + e.message)
+           throw e
+       }
+   }
+   ```
 
-    In `OfflineOpenViewModel.kt`:
+   In `OfflineOpenViewModel.kt`:
 
-    ```Kotlin
-    init {
-        viewModelScope.launch(Dispatchers.Default) {
-            val isMultipleUserMode =
-                UserSecureStoreDelegate.getInstance().getRuntimeMultipleUserMode()
-            val appConfig = FlowContextRegistry.flowContext.appConfig
+   ```Kotlin
+   init {
+       viewModelScope.launch(Dispatchers.Default) {
+           val isMultipleUserMode =
+               UserSecureStoreDelegate.getInstance().getRuntimeMultipleUserMode()
+           val appConfig = FlowContextRegistry.flowContext.appConfig
 
-            if (OfflineWorkerUtil.initializeOffline(application, appConfig, isMultipleUserMode)) {
-                startOpenOffline()
-            } else {
-                _uiState.update { currentState ->
-                    currentState.copy(
-                        result = OpenResult.OpenSuccess()
-                    )
-                }
-            }
-        }
-    }
-    ```
+           if (OfflineWorkerUtil.initializeOffline(application, appConfig, isMultipleUserMode)) {
+               startOpenOffline()
+           } else {
+               _uiState.update { currentState ->
+                   currentState.copy(
+                       result = OpenResult.OpenSuccess()
+                   )
+               }
+           }
+       }
+   }
+   ```
 
 6.  Unlike the single-user mode scenario, the encryption key is not generated by the client code, but rather retrieved from the server by SDK. Client code can acquire the key using the `UserSecureStoreDelegate.getInstance().getOfflineEncryptionKey()` API call.
 
@@ -212,66 +212,66 @@ The following cases are not supported in multi-user mode:
 
 6.  On Windows, press **`Ctrl+F12`**, or on a Mac, press **`command+F12`**, and type **`initializeOffline`** to navigate to the `initializeOffline` method. Notice that for the `OfflineODataParameters` instance, the value of the `isForceUploadOnUserSwitch` parameter is set based on the value of `runtimeMultipleUserMode`. This value is retrieved from the `UserSecureStoreDelegate.getInstance().getRuntimeMultipleUserModeAsync()` API call in `MainBusinessActivity.kt`.
 
-    ```Kotlin
-    /*
-     * Create OfflineODataProvider
-     * This is a blocking call, no data will be transferred until open, download, upload
-     */
-    @JvmStatic
-    fun initializeOffline(
-        context: Context,
-        appConfig: AppConfig,
-        runtimeMultipleUserMode: Boolean
-    ) {
-        ...
+   ```Kotlin
+   /*
+    * Create OfflineODataProvider
+    * This is a blocking call, no data will be transferred until open, download, upload
+    */
+   @JvmStatic
+   fun initializeOffline(
+       context: Context,
+       appConfig: AppConfig,
+       runtimeMultipleUserMode: Boolean
+   ) {
+       ...
 
-        try {
-            ...
+       try {
+           ...
 
-            val offlineODataParameters = OfflineODataParameters().apply {
-                ...
+           val offlineODataParameters = OfflineODataParameters().apply {
+               ...
 
-                isForceUploadOnUserSwitch = runtimeMultipleUserMode
-                val encryptionKey = if (runtimeMultipleUserMode) {
-                    UserSecureStoreDelegate.getInstance().getOfflineEncryptionKey()
-                } else { //If is single user mode, create and save a key into user secure store for accessing offline DB
-                    ...
-                }
-                storeEncryptionKey = encryptionKey
-            }.also {
-                ...
-            }
+               isForceUploadOnUserSwitch = runtimeMultipleUserMode
+               val encryptionKey = if (runtimeMultipleUserMode) {
+                   UserSecureStoreDelegate.getInstance().getOfflineEncryptionKey()
+               } else { //If is single user mode, create and save a key into user secure store for accessing offline DB
+                   ...
+               }
+               storeEncryptionKey = encryptionKey
+           }.also {
+               ...
+           }
 
-            ...
-        } catch (e: Exception) {
-            logger.error("Exception encountered setting up offline store: " + e.message)
-        }
-    }
-    ```
+           ...
+       } catch (e: Exception) {
+           logger.error("Exception encountered setting up offline store: " + e.message)
+       }
+   }
+   ```
 
-    In `MainBusinessActivity.kt`:
+   In `MainBusinessActivity.kt`:
 
-    ```Kotlin
-    override fun onResume() {
-        super.onResume()
+   ```Kotlin
+   override fun onResume() {
+       super.onResume()
 
-        ...
+       ...
 
-        spforLockAndWipe.getString(SAPWizardApplication.LOCK_WIPE_INVOKING_FLAG, null)?.let {
-            spforLockAndWipe.edit().remove(SAPWizardApplication.LOCK_WIPE_INVOKING_FLAG).apply()
-        } ?: run {
-            ...
+       spforLockAndWipe.getString(SAPWizardApplication.LOCK_WIPE_INVOKING_FLAG, null)?.let {
+           spforLockAndWipe.edit().remove(SAPWizardApplication.LOCK_WIPE_INVOKING_FLAG).apply()
+       } ?: run {
+           ...
 
-            val isMultipleUserMode = UserSecureStoreDelegate.getInstance().getRuntimeMultipleUserModeAsync() == true
+           val isMultipleUserMode = UserSecureStoreDelegate.getInstance().getRuntimeMultipleUserModeAsync() == true
 
-            ...
+           ...
 
-            OfflineWorkerUtil.initializeOffline(application, appConfig, isMultipleUserMode)
+           OfflineWorkerUtil.initializeOffline(application, appConfig, isMultipleUserMode)
 
-            ...
-        }
-    }
-    ```
+           ...
+       }
+   }
+   ```
 
 7.  Unlike the single-user mode scenario, the encryption key is not generated by the client code, but rather retrieved from the server by SDK. Client code can acquire the key using the `UserSecureStoreDelegate.getInstance().getOfflineEncryptionKey()` API call.
 
@@ -305,27 +305,27 @@ The following cases are not supported in multi-user mode:
 
     On Windows, press **`Ctrl+F`**, or on a Mac, press **`command+F`**, and type **`SyncFailureType.NETWORK_ERROR`** to move to the network error handling. When the network error occurs, make the **Offline Network Error Screen** visible and provide your logic for the button click event.
 
-    ```Kotlin
-    OfflineNetworkIssueScreen(
-        onBackButtonClick = navigateToWelcome,
-        onMainButtonClick = viewModel::startOpenOffline
-    )
-    ```
+   ```Kotlin
+   OfflineNetworkIssueScreen(
+       onBackButtonClick = navigateToWelcome,
+       onMainButtonClick = viewModel::startOpenOffline
+   )
+   ```
 
 5.  For **Offline Transaction Issue Screen**, the client code needs to set the user information of previous user and implement the logic for button click events.
 
     On Windows, press **`Ctrl+F`**, or on a Mac, press **`command+F`**, and type **`SyncFailureType.TRANSACTION_ISSUE`** to move to the transaction issue handling. When the transaction issue occurs, make the **Offline Transaction Issue Screen** visible, set the information of the previous user and provide your logic for the button click event. To get the information of the previous user, call the `getPreviousUser` method of the `OfflineOpenViewModel` class.
 
-    ```Kotlin
-    viewModel.previousUser?.let {
-                    OfflineTransactionIssueScreen(
-                        userName = it.name,
-                        email = it.email,
-                        onBackButtonClick = navigateToWelcome,
-                        onMainButtonClick = navigateToWelcome
-                    )
-                } ?: throw IllegalStateException("Unexpected offline transaction issue without previous user")
-    ```
+   ```Kotlin
+   viewModel.previousUser?.let {
+                   OfflineTransactionIssueScreen(
+                       userName = it.name,
+                       email = it.email,
+                       onBackButtonClick = navigateToWelcome,
+                       onMainButtonClick = navigateToWelcome
+                   )
+               } ?: throw IllegalStateException("Unexpected offline transaction issue without previous user")
+   ```
 
 [OPTION END]
 
@@ -353,62 +353,62 @@ The following cases are not supported in multi-user mode:
 
     On Windows, press **`Ctrl+F12`**, or, on a Mac, press **`command+F12`**, and type **`offlineNetworkErrorAction`** to move to the `offlineNetworkErrorAction` method. When the network error occurs, make the **Offline Network Error Screen** visible and provide your logic for the button click event.
 
-    ```Kotlin
-    private fun offlineNetworkErrorAction() {
-        this@MainBusinessActivity.runOnUiThread {
-            binding.offlineNetworkErrorScreen.visibility = View.VISIBLE
-            binding.offlineInitSyncScreen.visibility = View.INVISIBLE
-            binding.mainBusResumeProgressBar.visibility = View.INVISIBLE
-            val offlineNetworkErrorScreenSettings = OfflineNetworkErrorScreenSettings.Builder().build()
-            with(binding.offlineNetworkErrorScreen) {
-                initialize(offlineNetworkErrorScreenSettings)
-                // Provide logic for the button click event
-                setButtonClickListener(View.OnClickListener {
-                    OfflineWorkerUtil.addProgressListener(progressListener)
-                    OfflineWorkerUtil.open(application)
-                    startEntitySetListActivity()
-                    supportActionBar?.setTitle(R.string.initializing_offline_store)
-                    binding.offlineNetworkErrorScreen.visibility = View.INVISIBLE
-                    binding.offlineInitSyncScreen.visibility = View.VISIBLE
-                })
-            }
-        }
-    }
-    ```
+   ```Kotlin
+   private fun offlineNetworkErrorAction() {
+       this@MainBusinessActivity.runOnUiThread {
+           binding.offlineNetworkErrorScreen.visibility = View.VISIBLE
+           binding.offlineInitSyncScreen.visibility = View.INVISIBLE
+           binding.mainBusResumeProgressBar.visibility = View.INVISIBLE
+           val offlineNetworkErrorScreenSettings = OfflineNetworkErrorScreenSettings.Builder().build()
+           with(binding.offlineNetworkErrorScreen) {
+               initialize(offlineNetworkErrorScreenSettings)
+               // Provide logic for the button click event
+               setButtonClickListener(View.OnClickListener {
+                   OfflineWorkerUtil.addProgressListener(progressListener)
+                   OfflineWorkerUtil.open(application)
+                   startEntitySetListActivity()
+                   supportActionBar?.setTitle(R.string.initializing_offline_store)
+                   binding.offlineNetworkErrorScreen.visibility = View.INVISIBLE
+                   binding.offlineInitSyncScreen.visibility = View.VISIBLE
+               })
+           }
+       }
+   }
+   ```
 
 5.  For **Offline Transaction Issue Screen**, the client code needs to set the user information of previous user and implement the logic for button click events.
 
     On Windows, press **`Ctrl+F12`**, or, on a Mac, press **`command+F12`**, and type **`offlineTransactionIssueAction`** to move to the `offlineTransactionIssueAction` method. When the transaction error occurs, make the **Offline Transaction Issue Screen** visible, set the information of the previous user and provide your logic for the button click event. To get the information of the previous user, call the `getPreviousUserDetails` method from the flow context.
 
-    ```Kotlin
-    private fun offlineTransactionIssueAction() {
-        this@MainBusinessActivity.runOnUiThread {
-            binding.offlineTransactionIssueScreen.visibility = View.VISIBLE
-            binding.offlineInitSyncScreen.visibility = View.INVISIBLE
-            binding.mainBusResumeProgressBar.visibility = View.INVISIBLE
-            val offlineTransactionIssueScreenSettings = OfflineTransactionIssueScreenSettings.Builder().build()
-            with(binding.offlineTransactionIssueScreen) {
-                initialize(offlineTransactionIssueScreenSettings)
-                CoroutineScope(IO).launch {
-                    val user = FlowContextRegistry.flowContext.getPreviousUserDetails()
-                    withContext(Main) {
-                        user?.let {
-                            setPrevUserName(it.name)
-                            setPrevUserMail(it.email)
-                        } ?: run {
-                            setPrevUserName(OfflineWorkerUtil.offlineODataProvider!!.previousUser)
-                        }
-                    }
-                }
-            }
-            binding.offlineTransactionIssueScreen.setButtonClickListener(View.OnClickListener {
-                startActivity(Intent(this, WelcomeActivity::class.java).apply {
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                })
-            })
-        }
-    }
-    ```
+   ```Kotlin
+   private fun offlineTransactionIssueAction() {
+       this@MainBusinessActivity.runOnUiThread {
+           binding.offlineTransactionIssueScreen.visibility = View.VISIBLE
+           binding.offlineInitSyncScreen.visibility = View.INVISIBLE
+           binding.mainBusResumeProgressBar.visibility = View.INVISIBLE
+           val offlineTransactionIssueScreenSettings = OfflineTransactionIssueScreenSettings.Builder().build()
+           with(binding.offlineTransactionIssueScreen) {
+               initialize(offlineTransactionIssueScreenSettings)
+               CoroutineScope(IO).launch {
+                   val user = FlowContextRegistry.flowContext.getPreviousUserDetails()
+                   withContext(Main) {
+                       user?.let {
+                           setPrevUserName(it.name)
+                           setPrevUserMail(it.email)
+                       } ?: run {
+                           setPrevUserName(OfflineWorkerUtil.offlineODataProvider!!.previousUser)
+                       }
+                   }
+               }
+           }
+           binding.offlineTransactionIssueScreen.setButtonClickListener(View.OnClickListener {
+               startActivity(Intent(this, WelcomeActivity::class.java).apply {
+                   addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+               })
+           })
+       }
+   }
+   ```
 
 [OPTION END]
 
@@ -478,46 +478,46 @@ The following cases are not supported in multi-user mode:
 
     On Windows, press **`Ctrl+F12`**, or on a Mac, press **`command+F12`**, and type **`onOfflineEncryptionKeyReady`** to navigate to the `onOfflineEncryptionKeyReady` method. Examine the code and notice that it does some clean and reset work:
 
-    ```Kotlin
-    override fun onOfflineEncryptionKeyReady(key: String?) {
-        logger.info("offline key ready.")
-        userSwitchFlag =  if (!application.preferenceManager.getBoolean(OfflineWorkerUtil.PREF_DELETE_REGISTRATION, false)) {
-            flowContext.getPreviousUserId()?.let {
-                flowContext.getCurrentUserId() != it
-            } ?: false
-        } else {
-            application.preferenceManager.edit().putBoolean(OfflineWorkerUtil.PREF_DELETE_REGISTRATION, false).apply();
-            OfflineWorkerUtil.resetOffline(application)
-            true
-        }
+   ```Kotlin
+   override fun onOfflineEncryptionKeyReady(key: String?) {
+       logger.info("offline key ready.")
+       userSwitchFlag =  if (!application.preferenceManager.getBoolean(OfflineWorkerUtil.PREF_DELETE_REGISTRATION, false)) {
+           flowContext.getPreviousUserId()?.let {
+               flowContext.getCurrentUserId() != it
+           } ?: false
+       } else {
+           application.preferenceManager.edit().putBoolean(OfflineWorkerUtil.PREF_DELETE_REGISTRATION, false).apply();
+           OfflineWorkerUtil.resetOffline(application)
+           true
+       }
 
-        OfflineWorkerUtil.userSwitchFlag = userSwitchFlag
+       OfflineWorkerUtil.userSwitchFlag = userSwitchFlag
 
-        /*
-         * In single user scenario,
-         * if offline data store initialized and its encryption key not found,
-         * close and remove offline data store, meanwhile, set userSwitchFlag to true to trigger some important setting
-         */
-        if (UserSecureStoreDelegate.getInstance().getRuntimeMultipleUserModeAsync() == false
-                && application.preferenceManager.getBoolean(OfflineWorkerUtil.PREF_OFFLINE_INITIALIZED, false)
-                && UserSecureStoreDelegate.getInstance().getData<String>(OfflineWorkerUtil.OFFLINE_DATASTORE_ENCRYPTION_KEY) == null) {
-                userSwitchFlag = true
-                OfflineWorkerUtil.resetOffline(application)
-        }
+       /*
+        * In single user scenario,
+        * if offline data store initialized and its encryption key not found,
+        * close and remove offline data store, meanwhile, set userSwitchFlag to true to trigger some important setting
+        */
+       if (UserSecureStoreDelegate.getInstance().getRuntimeMultipleUserModeAsync() == false
+               && application.preferenceManager.getBoolean(OfflineWorkerUtil.PREF_OFFLINE_INITIALIZED, false)
+               && UserSecureStoreDelegate.getInstance().getData<String>(OfflineWorkerUtil.OFFLINE_DATASTORE_ENCRYPTION_KEY) == null) {
+               userSwitchFlag = true
+               OfflineWorkerUtil.resetOffline(application)
+       }
 
-        if (userSwitchFlag) {
-            application.preferenceManager.apply {
-                edit().putBoolean(OfflineWorkerUtil.PREF_OFFLINE_INITIALIZED, false)
-                        .apply()
-            }
-            application.repositoryFactory.reset()
-            OfflineWorkerUtil.offlineODataProvider?.close()
-            OfflineWorkerUtil.resetOfflineODataProvider()
-        }
-    }
-    ```
+       if (userSwitchFlag) {
+           application.preferenceManager.apply {
+               edit().putBoolean(OfflineWorkerUtil.PREF_OFFLINE_INITIALIZED, false)
+                       .apply()
+           }
+           application.repositoryFactory.reset()
+           OfflineWorkerUtil.offlineODataProvider?.close()
+           OfflineWorkerUtil.resetOfflineODataProvider()
+       }
+   }
+   ```
 
-    You can provide your own logic in this callback.
+   You can provide your own logic in this callback.
 
 [OPTION END]
 

--- a/tutorials/sdk-android-wizard-app-offline/sdk-android-wizard-app-offline.md
+++ b/tutorials/sdk-android-wizard-app-offline/sdk-android-wizard-app-offline.md
@@ -73,24 +73,24 @@ To protect the data in offline store, you must enable offline store encryption b
 
 2.  On Windows, press **`Ctrl+F12`**, or on a Mac, press **`command+F12`**, and type **`initializeOffline`**, to move to the `initializeOffline` method. Call the setter of `storeEncryptionKey` method of the `OfflineODataParameters` instance to encrypt the offline store. In single user mode, before you can get the encryption key using `UserSecureStoreDelegate`, you must generate and save an encryption key to `UserSecureStore` first.
 
-    ```Kotlin
-    val encryptionKey = if (runtimeMultipleUserMode) {
-        UserSecureStoreDelegate.getInstance().getOfflineEncryptionKey()
-    } else { //If is single user mode, create and save a key into user secure store for accessing offline DB
-        if (UserSecureStoreDelegate.getInstance().getData<String>(OFFLINE_DATASTORE_ENCRYPTION_KEY) == null) {
-            val bytes = ByteArray(32)
-            val random = SecureRandom()
-            random.nextBytes(bytes)
-            val key = Base64.encodeToString(bytes, Base64.NO_WRAP)
-            UserSecureStoreDelegate.getInstance().saveData(OFFLINE_DATASTORE_ENCRYPTION_KEY, key)
-            Arrays.fill(bytes, 0.toByte())
-            key
-        } else {
-            UserSecureStoreDelegate.getInstance().getData<String>(OFFLINE_DATASTORE_ENCRYPTION_KEY)
-        }
-    }
-    storeEncryptionKey = encryptionKey
-    ```
+   ```Kotlin
+   val encryptionKey = if (runtimeMultipleUserMode) {
+       UserSecureStoreDelegate.getInstance().getOfflineEncryptionKey()
+   } else { //If is single user mode, create and save a key into user secure store for accessing offline DB
+       if (UserSecureStoreDelegate.getInstance().getData<String>(OFFLINE_DATASTORE_ENCRYPTION_KEY) == null) {
+           val bytes = ByteArray(32)
+           val random = SecureRandom()
+           random.nextBytes(bytes)
+           val key = Base64.encodeToString(bytes, Base64.NO_WRAP)
+           UserSecureStoreDelegate.getInstance().saveData(OFFLINE_DATASTORE_ENCRYPTION_KEY, key)
+           Arrays.fill(bytes, 0.toByte())
+           key
+       } else {
+           UserSecureStoreDelegate.getInstance().getData<String>(OFFLINE_DATASTORE_ENCRYPTION_KEY)
+       }
+   }
+   storeEncryptionKey = encryptionKey
+   ```
 
 >For additional information about multiple user mode, see [Enable Multi-User Mode for Your Android Application](sdk-android-wizard-app-multiuser).
 
@@ -129,103 +129,103 @@ The application allows users to make changes against a local offline store and s
 
 1.  In Android Studio, on Windows, press **`Ctrl+N`**, or on a Mac, press **`command+O`**, and type **`OfflineOpenWorker`** to open `OfflineOpenWorker.kt` and examine the `open` method.
 
-    ```Kotlin
-    override suspend fun doWork(): Result = withContext(IO) {
-        ... ...
-        try {
-            result = suspendOpen()
-            ... ...
-        } finally {
-            ... ...
-        }
-        ... ...
-    }
+   ```Kotlin
+   override suspend fun doWork(): Result = withContext(IO) {
+       ... ...
+       try {
+           result = suspendOpen()
+           ... ...
+       } finally {
+           ... ...
+       }
+       ... ...
+   }
 
-    private suspend fun suspendOpen(): Result {
-        try {
-            OfflineWorkerUtil.offlineODataProvider?.open()
-            return Result.success()
-        } catch (exception: OfflineODataException) {
-            ... ...
-        }
-    }
-    ```
+   private suspend fun suspendOpen(): Result {
+       try {
+           OfflineWorkerUtil.offlineODataProvider?.open()
+           return Result.success()
+       } catch (exception: OfflineODataException) {
+           ... ...
+       }
+   }
+   ```
 
-    The worker's work is to call the `open` method of the `OfflineODataProvider` class to perform the open operation and pass the given callbacks through.
+   The worker's work is to call the `open` method of the `OfflineODataProvider` class to perform the open operation and pass the given callbacks through.
 
-    The `OfflineOpenWorker` class is called by the `open` method in `OfflineWorkerUtil.kt`, which is called by `OfflineOpenViewModel` when the user logs in to the application.
+   The `OfflineOpenWorker` class is called by the `open` method in `OfflineWorkerUtil.kt`, which is called by `OfflineOpenViewModel` when the user logs in to the application.
 
-    ```Kotlin
-    // In OfflineWorkerUtil.kt
-    fun open(context: Context): UUID {
-        ... ...
-        val openRequest = OneTimeWorkRequestBuilder<OfflineOpenWorker>()
-            .setConstraints(constraints)
-            .build()
-        ... ...
-    }
-    ```
+   ```Kotlin
+   // In OfflineWorkerUtil.kt
+   fun open(context: Context): UUID {
+       ... ...
+       val openRequest = OneTimeWorkRequestBuilder<OfflineOpenWorker>()
+           .setConstraints(constraints)
+           .build()
+       ... ...
+   }
+   ```
 
-    ```Kotlin
-    // In OfflineOpenViewModel.kt
-    fun startOpenOffline() {
-        OfflineWorkerUtil.addProgressListener(progressListener)
-        _uiState.update { SyncUIState() } //reset ui state for relaunch
-        val openRequestId = OfflineWorkerUtil.open(getApplication())
-        ... ...
-    }
-    ```
+   ```Kotlin
+   // In OfflineOpenViewModel.kt
+   fun startOpenOffline() {
+       OfflineWorkerUtil.addProgressListener(progressListener)
+       _uiState.update { SyncUIState() } //reset ui state for relaunch
+       val openRequestId = OfflineWorkerUtil.open(getApplication())
+       ... ...
+   }
+   ```
 
 2.  In Android Studio, on Windows, press **`Ctrl+N`**, or on a Mac, press **`command+O`**, and type **`OfflineSyncWorker`** to open `OfflineSyncWorker.kt` and examine the `download` and `upload` methods.
 
-    ```Kotlin
-    override suspend fun doWork(): Result = withContext(IO) {
-        ... ...
+   ```Kotlin
+   override suspend fun doWork(): Result = withContext(IO) {
+       ... ...
 
-        OfflineWorkerUtil.offlineODataProvider?.let { provider ->
-            ... ...
-            try {
-                OfflineWorkerUtil.addProgressListener(progressListener)
-                logger.info("Start uploading data...")
-                provider.upload()
-                logger.info("Start downloading data...")
-                startPointForSync = progressListener.totalStepsForTwoProgresses / 2
-                provider.download()
-            } catch (exception: OfflineODataException) {
-                ... ...
-            } finally {
-                ... ...
-            }
-        }
+       OfflineWorkerUtil.offlineODataProvider?.let { provider ->
+           ... ...
+           try {
+               OfflineWorkerUtil.addProgressListener(progressListener)
+               logger.info("Start uploading data...")
+               provider.upload()
+               logger.info("Start downloading data...")
+               startPointForSync = progressListener.totalStepsForTwoProgresses / 2
+               provider.download()
+           } catch (exception: OfflineODataException) {
+               ... ...
+           } finally {
+               ... ...
+           }
+       }
 
-        ... ...
-    }
-    ```
+       ... ...
+   }
+   ```
 
-    The worker's work is to call the `download` and `upload` method of the `OfflineODataProvider` class to perform the sync operation.
+   The worker's work is to call the `download` and `upload` method of the `OfflineODataProvider` class to perform the sync operation.
 
-    The `OfflineSyncWorker` class is called by the `sync` method in `OfflineWorkerUtil.kt`, which is called by `EntitySetViewModel` when the user wants to perform a sync. When an entity is created locally in the offline store, its primary key is left unset. This is because when the user performs an `upload`, the server will set the primary key for the client. An `upload` and a `download` are normally performed together because the `download` may return updated values from the server, such as a newly-created primary key.
+   The `OfflineSyncWorker` class is called by the `sync` method in `OfflineWorkerUtil.kt`, which is called by `EntitySetViewModel` when the user wants to perform a sync. When an entity is created locally in the offline store, its primary key is left unset. This is because when the user performs an `upload`, the server will set the primary key for the client. An `upload` and a `download` are normally performed together because the `download` may return updated values from the server, such as a newly-created primary key.
 
-    ```Kotlin
-    // In OfflineWorkerUtil.kt
-    fun sync(context: Context): UUID {
-        ... ...
+   ```Kotlin
+   // In OfflineWorkerUtil.kt
+   fun sync(context: Context): UUID {
+       ... ...
 
-        val syncRequest = OneTimeWorkRequestBuilder<OfflineSyncWorker>()
-            .setConstraints(constraints)
-            .build()
+       val syncRequest = OneTimeWorkRequestBuilder<OfflineSyncWorker>()
+           .setConstraints(constraints)
+           .build()
 
-        ... ...
-    }
-    ```
+       ... ...
+   }
+   ```
 
-    ```Kotlin
-    // In EntitySetViewModel.kt
-    fun startSync() {
-        val requestId = OfflineWorkerUtil.sync(getApplication())
-        ... ...
-    }
-    ```
+   ```Kotlin
+   // In EntitySetViewModel.kt
+   fun startSync() {
+       val requestId = OfflineWorkerUtil.sync(getApplication())
+       ... ...
+   }
+   ```
 
 [OPTION END]
 
@@ -233,99 +233,99 @@ The application allows users to make changes against a local offline store and s
 
 1.  In Android Studio, on Windows, press **`Ctrl+N`**, or on a Mac, press **`command+O`**, and type **`OfflineOpenWorker`** to open `OfflineOpenWorker.kt` and examine the `open` method.
 
-    ```Kotlin
-    override suspend fun doWork(): Result = withContext(IO) {
-        ... ...
-        OfflineWorkerUtil.offlineODataProvider?.also { provider ->
-            provider.open({
-                ... ...
-            }, { exception ->
-                ... ...
-            })
-        }
-        ... ...
-    }
-    ```
+   ```Kotlin
+   override suspend fun doWork(): Result = withContext(IO) {
+       ... ...
+       OfflineWorkerUtil.offlineODataProvider?.also { provider ->
+           provider.open({
+               ... ...
+           }, { exception ->
+               ... ...
+           })
+       }
+       ... ...
+   }
+   ```
 
-    The worker's work is to call the `open` method of the `OfflineODataProvider` class to perform the open operation and pass the given callbacks through.
+   The worker's work is to call the `open` method of the `OfflineODataProvider` class to perform the open operation and pass the given callbacks through.
 
-    The `OfflineOpenWorker` class is called by the `open` method in `OfflineWorkerUtil.kt`, which is called by `MainBusinessActivity` when the user logs in to the application.
+   The `OfflineOpenWorker` class is called by the `open` method in `OfflineWorkerUtil.kt`, which is called by `MainBusinessActivity` when the user logs in to the application.
 
-    ```Kotlin
-    // In OfflineWorkerUtil.kt
-    @JvmStatic
-    fun open(context: Context) {
-        ... ...
-        openRequest = OneTimeWorkRequestBuilder<OfflineOpenWorker>()
-            .setConstraints(constraints)
-            .build()
-        ... ...
-    }
-    ```
+   ```Kotlin
+   // In OfflineWorkerUtil.kt
+   @JvmStatic
+   fun open(context: Context) {
+       ... ...
+       openRequest = OneTimeWorkRequestBuilder<OfflineOpenWorker>()
+           .setConstraints(constraints)
+           .build()
+       ... ...
+   }
+   ```
 
-    ```Kotlin
-    // In MainBusinessActivity.kt
-    override fun onResume() {
-        ... ...
-        spforLockAndWipe.getString(SAPWizardApplication.LOCK_WIPE_INVOKING_FLAG, null)?.let {
-            ... ...
-        } ?: run {
-            ... ...
-            OfflineWorkerUtil.open(application)
-            ... ...
-        }
-    }
-    ```
+   ```Kotlin
+   // In MainBusinessActivity.kt
+   override fun onResume() {
+       ... ...
+       spforLockAndWipe.getString(SAPWizardApplication.LOCK_WIPE_INVOKING_FLAG, null)?.let {
+           ... ...
+       } ?: run {
+           ... ...
+           OfflineWorkerUtil.open(application)
+           ... ...
+       }
+   }
+   ```
 
 2.  In Android Studio, on Windows, press **`Ctrl+N`**, or on a Mac, press **`command+O`**, and type **`OfflineSyncWorker`** to open `OfflineSyncWorker.kt` and examine the `download` and `upload` methods.
 
-    ```Kotlin
-    override suspend fun doWork(): Result = withContext(IO) {
-        ... ...
+   ```Kotlin
+   override suspend fun doWork(): Result = withContext(IO) {
+       ... ...
 
-        OfflineWorkerUtil.offlineODataProvider?.also { provider ->
-            ... ...
-            provider.upload({
-                ... ...
-                provider.download({
-                    ... ...
-                }, {
-                    ... ...
-                })
-            }, {
-                ... ...
-            })
-        }
+       OfflineWorkerUtil.offlineODataProvider?.also { provider ->
+           ... ...
+           provider.upload({
+               ... ...
+               provider.download({
+                   ... ...
+               }, {
+                   ... ...
+               })
+           }, {
+               ... ...
+           })
+       }
 
-        ... ...
-    }
-    ```
+       ... ...
+   }
+   ```
 
-    The worker's work is to call the `download` and `upload` method of the `OfflineODataProvider` class to perform the sync operation and pass the given callbacks through.
+   The worker's work is to call the `download` and `upload` method of the `OfflineODataProvider` class to perform the sync operation and pass the given callbacks through.
 
-    The `OfflineSyncWorker` class is called by the `sync` method in `OfflineWorkerUtil.kt`, which is called by `EntitySetListActivity` when the user wants to perform a sync. When an entity is created locally in the offline store, its primary key is left unset. This is because when the user performs an `upload`, the server will set the primary key for the client. An `upload` and a `download` are normally performed together because the `download` may return updated values from the server, such as a newly-created primary key.
+   The `OfflineSyncWorker` class is called by the `sync` method in `OfflineWorkerUtil.kt`, which is called by `EntitySetListActivity` when the user wants to perform a sync. When an entity is created locally in the offline store, its primary key is left unset. This is because when the user performs an `upload`, the server will set the primary key for the client. An `upload` and a `download` are normally performed together because the `download` may return updated values from the server, such as a newly-created primary key.
 
-    ```Kotlin
-    // In OfflineWorkerUtil.kt
-    @JvmStatic
-    fun sync(context: Context) {
-        ... ...
+   ```Kotlin
+   // In OfflineWorkerUtil.kt
+   @JvmStatic
+   fun sync(context: Context) {
+       ... ...
 
-        syncRequest = OneTimeWorkRequestBuilder<OfflineSyncWorker>()
-            .setConstraints(constraints)
-            .build()
+       syncRequest = OneTimeWorkRequestBuilder<OfflineSyncWorker>()
+           .setConstraints(constraints)
+           .build()
 
-        ... ...
-    }
-    ```
+       ... ...
+   }
+   ```
 
-    ```Kotlin
-    // In EntitySetListActivity.kt
-    private fun synchronize() {
-        OfflineWorkerUtil.sync(application)
-        ... ...
-    }
-    ```
+   ```Kotlin
+   // In EntitySetListActivity.kt
+   private fun synchronize() {
+       OfflineWorkerUtil.sync(application)
+       ... ...
+   }
+   ```
 
 [OPTION END]
 
@@ -389,14 +389,14 @@ In this section we will create an **Error Information** screen that displays the
 
 2.  Add the following values.
 
-    ```XML
-    <string name="error_header">Error Information</string>
-    <string name="request_method">Request Method</string>
-    <string name="request_status">Request Status</string>
-    <string name="request_message">Request Message</string>
-    <string name="request_body">Request Body</string>
-    <string name="request_url">Request URL</string>
-    ```
+   ```XML
+   <string name="error_header">Error Information</string>
+   <string name="request_method">Request Method</string>
+   <string name="request_status">Request Status</string>
+   <string name="request_message">Request Message</string>
+   <string name="request_body">Request Body</string>
+   <string name="request_url">Request URL</string>
+   ```
 
 3.  Create a new screen in the `app/kotlin+java/com.sap.wizapp/ui/odata/screens` folder by right-clicking, then selecting **New** > **Kotlin Class/File** > **File**. Name the new file **`ErrorScreen`**.
 
@@ -404,301 +404,301 @@ In this section we will create an **Error Information** screen that displays the
 
     In the package statement and the import, if needed, replace `com.sap.wizapp` with the package name of your project.
 
-    ```Kotlin
-    package com.sap.wizapp.ui.odata.screens
+   ```Kotlin
+   package com.sap.wizapp.ui.odata.screens
 
-    import androidx.compose.foundation.layout.padding
-    import androidx.compose.foundation.lazy.LazyColumn
-    import androidx.compose.material3.Text
-    import androidx.compose.runtime.Composable
-    import androidx.compose.ui.Modifier
-    import androidx.compose.ui.res.stringResource
-    import androidx.compose.ui.unit.dp
-    import androidx.lifecycle.viewmodel.compose.viewModel
-    import com.sap.cloud.mobile.fiori.compose.common.FioriDivider
-    import com.sap.cloud.mobile.fiori.compose.navigation.ui.HeadlineText
-    import com.sap.cloud.mobile.fiori.compose.theme.FioriTextStyleOverline
-    import com.sap.cloud.mobile.fiori.compose.theme.TextAppearanceFioriSubtitle1
-    import com.sap.wizapp.R
-    import org.json.JSONObject
+   import androidx.compose.foundation.layout.padding
+   import androidx.compose.foundation.lazy.LazyColumn
+   import androidx.compose.material3.Text
+   import androidx.compose.runtime.Composable
+   import androidx.compose.ui.Modifier
+   import androidx.compose.ui.res.stringResource
+   import androidx.compose.ui.unit.dp
+   import androidx.lifecycle.viewmodel.compose.viewModel
+   import com.sap.cloud.mobile.fiori.compose.common.FioriDivider
+   import com.sap.cloud.mobile.fiori.compose.navigation.ui.HeadlineText
+   import com.sap.cloud.mobile.fiori.compose.theme.FioriTextStyleOverline
+   import com.sap.cloud.mobile.fiori.compose.theme.TextAppearanceFioriSubtitle1
+   import com.sap.wizapp.R
+   import org.json.JSONObject
 
-    const val ERROR_URL = "requestURL"
-    const val ERROR_CODE = "statusCode"
-    const val ERROR_METHOD = "method"
-    const val ERROR_BODY = "body"
-    const val ERROR_MESSAGE = "message"
+   const val ERROR_URL = "requestURL"
+   const val ERROR_CODE = "statusCode"
+   const val ERROR_METHOD = "method"
+   const val ERROR_BODY = "body"
+   const val ERROR_MESSAGE = "message"
 
-    @Composable
-    fun ErrorScreen(navigateUp: () -> Unit, errorInfo: String?) {
-        // Display the error information
+   @Composable
+   fun ErrorScreen(navigateUp: () -> Unit, errorInfo: String?) {
+       // Display the error information
 
-        val errorInfoJson = errorInfo?.let{ JSONObject(errorInfo) }
-        val errorUrl = errorInfoJson?.getString(ERROR_URL)
-        val errorCode = errorInfoJson?.getInt(ERROR_CODE)
-        val errorMethod = errorInfoJson?.getString(ERROR_METHOD)
-        val errorBody = errorInfoJson?.getString(ERROR_BODY)
-        val errorMessage = errorInfoJson?.getString(ERROR_MESSAGE)
+       val errorInfoJson = errorInfo?.let{ JSONObject(errorInfo) }
+       val errorUrl = errorInfoJson?.getString(ERROR_URL)
+       val errorCode = errorInfoJson?.getInt(ERROR_CODE)
+       val errorMethod = errorInfoJson?.getString(ERROR_METHOD)
+       val errorBody = errorInfoJson?.getString(ERROR_BODY)
+       val errorMessage = errorInfoJson?.getString(ERROR_MESSAGE)
 
-        OperationScreen(
-            screenSettings = OperationScreenSettings(
-                title = stringResource(id = R.string.application_name),
-                navigateUp = navigateUp,
-            ),
-            modifier = Modifier,
-            viewModel = viewModel()
-        ) {
-            LazyColumn {
-                item {
-                    HeadlineText(
-                        text = stringResource(id = R.string.error_header),
-                        modifier = Modifier.padding(16.dp)
-                    )
-                    FioriDivider()
-                    Text(
-                        text = stringResource(id = R.string.request_message).uppercase(),
-                        modifier = Modifier.padding(16.dp),
-                        style = FioriTextStyleOverline
-                    )
-                    Text(
-                        text = errorMessage ?: stringResource(id = R.string.request_message),
-                        modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
-                        style = TextAppearanceFioriSubtitle1
-                    )
-                    FioriDivider()
-                    Text(
-                        text = stringResource(id = R.string.request_body).uppercase(),
-                        modifier = Modifier.padding(16.dp),
-                        style = FioriTextStyleOverline
-                    )
-                    Text(
-                        text = errorBody ?: stringResource(id = R.string.request_body),
-                        modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
-                        style = TextAppearanceFioriSubtitle1
-                    )
-                    FioriDivider()
-                    Text(
-                        text = stringResource(id = R.string.request_url).uppercase(),
-                        modifier = Modifier.padding(16.dp),
-                        style = FioriTextStyleOverline
-                    )
-                    Text(
-                        text = errorUrl ?: stringResource(id = R.string.request_url),
-                        modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
-                        style = TextAppearanceFioriSubtitle1
-                    )
-                    FioriDivider()
-                    Text(
-                        text = stringResource(id = R.string.request_status).uppercase(),
-                        modifier = Modifier.padding(16.dp),
-                        style = FioriTextStyleOverline
-                    )
-                    Text(
-                        text = (errorCode ?: 0).toString(),
-                        modifier = Modifier.padding(start = 16.dp, bottom = 16.dp),
-                        style = TextAppearanceFioriSubtitle1
-                    )
-                    FioriDivider()
-                    Text(
-                        text = stringResource(id = R.string.request_method).uppercase(),
-                        modifier = Modifier.padding(16.dp),
-                        style = FioriTextStyleOverline
-                    )
-                    Text(
-                        text = errorMethod ?: stringResource(id = R.string.request_method),
-                        modifier = Modifier.padding(start = 16.dp, bottom = 16.dp),
-                        style = TextAppearanceFioriSubtitle1
-                    )
-                    FioriDivider()
-                }
-            }
-        }
-    }
-    ```
+       OperationScreen(
+           screenSettings = OperationScreenSettings(
+               title = stringResource(id = R.string.application_name),
+               navigateUp = navigateUp,
+           ),
+           modifier = Modifier,
+           viewModel = viewModel()
+       ) {
+           LazyColumn {
+               item {
+                   HeadlineText(
+                       text = stringResource(id = R.string.error_header),
+                       modifier = Modifier.padding(16.dp)
+                   )
+                   FioriDivider()
+                   Text(
+                       text = stringResource(id = R.string.request_message).uppercase(),
+                       modifier = Modifier.padding(16.dp),
+                       style = FioriTextStyleOverline
+                   )
+                   Text(
+                       text = errorMessage ?: stringResource(id = R.string.request_message),
+                       modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
+                       style = TextAppearanceFioriSubtitle1
+                   )
+                   FioriDivider()
+                   Text(
+                       text = stringResource(id = R.string.request_body).uppercase(),
+                       modifier = Modifier.padding(16.dp),
+                       style = FioriTextStyleOverline
+                   )
+                   Text(
+                       text = errorBody ?: stringResource(id = R.string.request_body),
+                       modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
+                       style = TextAppearanceFioriSubtitle1
+                   )
+                   FioriDivider()
+                   Text(
+                       text = stringResource(id = R.string.request_url).uppercase(),
+                       modifier = Modifier.padding(16.dp),
+                       style = FioriTextStyleOverline
+                   )
+                   Text(
+                       text = errorUrl ?: stringResource(id = R.string.request_url),
+                       modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
+                       style = TextAppearanceFioriSubtitle1
+                   )
+                   FioriDivider()
+                   Text(
+                       text = stringResource(id = R.string.request_status).uppercase(),
+                       modifier = Modifier.padding(16.dp),
+                       style = FioriTextStyleOverline
+                   )
+                   Text(
+                       text = (errorCode ?: 0).toString(),
+                       modifier = Modifier.padding(start = 16.dp, bottom = 16.dp),
+                       style = TextAppearanceFioriSubtitle1
+                   )
+                   FioriDivider()
+                   Text(
+                       text = stringResource(id = R.string.request_method).uppercase(),
+                       modifier = Modifier.padding(16.dp),
+                       style = FioriTextStyleOverline
+                   )
+                   Text(
+                       text = errorMethod ?: stringResource(id = R.string.request_method),
+                       modifier = Modifier.padding(start = 16.dp, bottom = 16.dp),
+                       style = TextAppearanceFioriSubtitle1
+                   )
+                   FioriDivider()
+               }
+           }
+       }
+   }
+   ```
 
 5.  On Windows, press **`Ctrl+Shift+N`**, or on a Mac, press **`command+shift+O`**, and type **`EntitySetsScreen`** to open `EntitySetsScreen.kt`.
 
 6.  Add a parameter after `navigateToSettings` in the `EntitySetScreen` function:
 
-    ```Kotlin
-    @Composable
-    fun EntitySetScreen(
-        list: List<EntityScreenInfo>,
-        onRowClick: (EntityType) -> Unit,
-        modifier: Modifier = Modifier,
-        navigateToSettings: () -> Unit,
-        navigateToErrorScreen: (String) -> Unit
-    ) {
-    ```
+   ```Kotlin
+   @Composable
+   fun EntitySetScreen(
+       list: List<EntityScreenInfo>,
+       onRowClick: (EntityType) -> Unit,
+       modifier: Modifier = Modifier,
+       navigateToSettings: () -> Unit,
+       navigateToErrorScreen: (String) -> Unit
+   ) {
+   ```
 
 7.  Add the following imports:
 
-    ```Kotlin
-    import android.util.Log
-    import com.sap.cloud.mobile.kotlin.odata.offline.OfflineODataException
-    import org.json.JSONException
-    import org.json.JSONObject
-    ```
+   ```Kotlin
+   import android.util.Log
+   import com.sap.cloud.mobile.kotlin.odata.offline.OfflineODataException
+   import org.json.JSONException
+   import org.json.JSONObject
+   ```
 
 8.  Modify the `EntitySetScreen` in the `EntitySetScreenPreview` function correspondingly.
 
-    ```Kotlin
-    @Preview
-    @Composable
-    fun EntitySetScreenPreview() {
-        val entityTypeNames = EntityScreenInfo.entries
-        EntitySetScreen(entityTypeNames, { println("click $it row") }, navigateToSettings = {}, navigateToErrorScreen = {})
-    }
-    ```
+   ```Kotlin
+   @Preview
+   @Composable
+   fun EntitySetScreenPreview() {
+       val entityTypeNames = EntityScreenInfo.entries
+       EntitySetScreen(entityTypeNames, { println("click $it row") }, navigateToSettings = {}, navigateToErrorScreen = {})
+   }
+   ```
 
 9.  In the action tiems list of the `OperationScreen`, modify the action of `ActionItem` `synchronize` from `viewModel::startSync` to the following, which queries the error archive and displays information to the user about the first error encountered after sync finished:
 
-    ```Kotlin
-    viewModel.startSync()
-    val provider = OfflineWorkerUtil.offlineODataProvider
+   ```Kotlin
+   viewModel.startSync()
+   val provider = OfflineWorkerUtil.offlineODataProvider
 
-    try {
-        val errorArchive = provider!!.getErrorArchive()
+   try {
+       val errorArchive = provider!!.getErrorArchive()
 
-        for (errorEntity in errorArchive) {
-            val requestURL = errorEntity.requestURL
-            val method = errorEntity.requestMethod
-            val message = errorEntity.message
-            val statusCode = errorEntity.httpStatusCode ?: 0
-            val body = errorEntity.requestBody
+       for (errorEntity in errorArchive) {
+           val requestURL = errorEntity.requestURL
+           val method = errorEntity.requestMethod
+           val message = errorEntity.message
+           val statusCode = errorEntity.httpStatusCode ?: 0
+           val body = errorEntity.requestBody
 
-            Log.e("ErrorArchive", "RequestURL: $requestURL")
-            Log.e("ErrorArchive", "HTTP Status Code: $statusCode")
-            Log.e("ErrorArchive", "Method: $method")
-            Log.e("ErrorArchive", "Message: $message")
-            Log.e("ErrorArchive", "Body: $body")
+           Log.e("ErrorArchive", "RequestURL: $requestURL")
+           Log.e("ErrorArchive", "HTTP Status Code: $statusCode")
+           Log.e("ErrorArchive", "Method: $method")
+           Log.e("ErrorArchive", "Message: $message")
+           Log.e("ErrorArchive", "Body: $body")
 
-            val finalMessage = try {
-                val jsonObj = message?.let { JSONObject(it) }
-                jsonObj?.let {
-                    jsonObj.getJSONObject("error").getString("message")
-                }
-            } catch (e: JSONException) {
-                e.printStackTrace()
-                message
-            }
+           val finalMessage = try {
+               val jsonObj = message?.let { JSONObject(it) }
+               jsonObj?.let {
+                   jsonObj.getJSONObject("error").getString("message")
+               }
+           } catch (e: JSONException) {
+               e.printStackTrace()
+               message
+           }
 
-            val errorInfo = JSONObject().apply {
-                                put(ERROR_URL, requestURL)
-                                put(ERROR_METHOD, method)
-                                put(ERROR_MESSAGE, finalMessage)
-                                put(ERROR_CODE, statusCode)
-                                put(ERROR_BODY, body)
-                            }
+           val errorInfo = JSONObject().apply {
+                               put(ERROR_URL, requestURL)
+                               put(ERROR_METHOD, method)
+                               put(ERROR_MESSAGE, finalMessage)
+                               put(ERROR_CODE, statusCode)
+                               put(ERROR_BODY, body)
+                           }
 
-            // Reverts all failing entities to the previous state or set
-            // offlineODataParameters.setEnableIndividualErrorArchiveDeletion(true);
-            // to cause the deleteEntity call to only revert the specified entity
-            // https://help.sap.com/doc/f53c64b93e5140918d676b927a3cd65b/Cloud/en-US/docs-en/guides/features/offline/common/handling-failed-requests/reverting-error-state.html
-            // provider.deleteEntity(errorEntity, null, null);
-            navigateToErrorScreen(errorInfo.toString())
-            break //For simplicity, only show the first error encountered
-        }
-    } catch (e: OfflineODataException) {
-        e.printStackTrace()
-    }
-    ```
+           // Reverts all failing entities to the previous state or set
+           // offlineODataParameters.setEnableIndividualErrorArchiveDeletion(true);
+           // to cause the deleteEntity call to only revert the specified entity
+           // https://help.sap.com/doc/f53c64b93e5140918d676b927a3cd65b/Cloud/en-US/docs-en/guides/features/offline/common/handling-failed-requests/reverting-error-state.html
+           // provider.deleteEntity(errorEntity, null, null);
+           navigateToErrorScreen(errorInfo.toString())
+           break //For simplicity, only show the first error encountered
+       }
+   } catch (e: OfflineODataException) {
+       e.printStackTrace()
+   }
+   ```
 
-    After modification, the `ActionItem` of `synchronize` should look like this:
+   After modification, the `ActionItem` of `synchronize` should look like this:
 
-    ```Kotlin
-    ActionItem(
-        nameRes = R.string.synchronize_action,
-        overflowMode = OverflowMode.ALWAYS_OVERFLOW,
-        doAction = {
-            viewModel.startSync()
-            val provider = OfflineWorkerUtil.offlineODataProvider
+   ```Kotlin
+   ActionItem(
+       nameRes = R.string.synchronize_action,
+       overflowMode = OverflowMode.ALWAYS_OVERFLOW,
+       doAction = {
+           viewModel.startSync()
+           val provider = OfflineWorkerUtil.offlineODataProvider
 
-            try {
-                val errorArchive = provider!!.getErrorArchive()
+           try {
+               val errorArchive = provider!!.getErrorArchive()
 
-                for (errorEntity in errorArchive) {
-                    val requestURL = errorEntity.requestURL
-                    val method = errorEntity.requestMethod
-                    val message = errorEntity.message
-                    val statusCode = errorEntity.httpStatusCode ?: 0
-                    val body = errorEntity.requestBody
+               for (errorEntity in errorArchive) {
+                   val requestURL = errorEntity.requestURL
+                   val method = errorEntity.requestMethod
+                   val message = errorEntity.message
+                   val statusCode = errorEntity.httpStatusCode ?: 0
+                   val body = errorEntity.requestBody
 
-                    Log.e("ErrorArchive", "RequestURL: $requestURL")
-                    Log.e("ErrorArchive", "HTTP Status Code: $statusCode")
-                    Log.e("ErrorArchive", "Method: $method")
-                    Log.e("ErrorArchive", "Message: $message")
-                    Log.e("ErrorArchive", "Body: $body")
+                   Log.e("ErrorArchive", "RequestURL: $requestURL")
+                   Log.e("ErrorArchive", "HTTP Status Code: $statusCode")
+                   Log.e("ErrorArchive", "Method: $method")
+                   Log.e("ErrorArchive", "Message: $message")
+                   Log.e("ErrorArchive", "Body: $body")
 
-                    val finalMessage = try {
-                        val jsonObj = message?.let { JSONObject(it) }
-                        jsonObj?.let {
-                            jsonObj.getJSONObject("error").getString("message")
-                        }
-                    } catch (e: JSONException) {
-                        e.printStackTrace()
-                        message
-                    }
+                   val finalMessage = try {
+                       val jsonObj = message?.let { JSONObject(it) }
+                       jsonObj?.let {
+                           jsonObj.getJSONObject("error").getString("message")
+                       }
+                   } catch (e: JSONException) {
+                       e.printStackTrace()
+                       message
+                   }
 
-                    val errorInfo = JSONObject().apply {
-                                        put(ERROR_URL, requestURL)
-                                        put(ERROR_METHOD, method)
-                                        put(ERROR_MESSAGE, finalMessage)
-                                        put(ERROR_CODE, statusCode)
-                                        put(ERROR_BODY, body)
-                                    }
+                   val errorInfo = JSONObject().apply {
+                                       put(ERROR_URL, requestURL)
+                                       put(ERROR_METHOD, method)
+                                       put(ERROR_MESSAGE, finalMessage)
+                                       put(ERROR_CODE, statusCode)
+                                       put(ERROR_BODY, body)
+                                   }
 
-                    // Reverts all failing entities to the previous state or set
-                    // offlineODataParameters.setEnableIndividualErrorArchiveDeletion(true);
-                    // to cause the deleteEntity call to only revert the specified entity
-                    // https://help.sap.com/doc/f53c64b93e5140918d676b927a3cd65b/Cloud/en-US/docs-en/guides/features/offline/common/handling-failed-requests/reverting-error-state.html
-                    // provider.deleteEntity(errorEntity, null, null);
-                    navigateToErrorScreen(errorInfo.toString())
-                    break //For simplicity, only show the first error encountered
-                }
-            } catch (e: OfflineODataException) {
-                e.printStackTrace()
-            }
-        }
-    ),
-    ```
+                   // Reverts all failing entities to the previous state or set
+                   // offlineODataParameters.setEnableIndividualErrorArchiveDeletion(true);
+                   // to cause the deleteEntity call to only revert the specified entity
+                   // https://help.sap.com/doc/f53c64b93e5140918d676b927a3cd65b/Cloud/en-US/docs-en/guides/features/offline/common/handling-failed-requests/reverting-error-state.html
+                   // provider.deleteEntity(errorEntity, null, null);
+                   navigateToErrorScreen(errorInfo.toString())
+                   break //For simplicity, only show the first error encountered
+               }
+           } catch (e: OfflineODataException) {
+               e.printStackTrace()
+           }
+       }
+   ),
+   ```
 
 10. On Windows, press **`Ctrl+Shift+N`**, or on a Mac, press **`command+shift+O`**, and type **`ODataNavHost`** to open `ODataNavHost.kt`.
 
 11. Add the following imports:
 
-    ```Kotlin
-    import androidx.navigation.NavType
-    import androidx.navigation.navArgument
-    ```
+   ```Kotlin
+   import androidx.navigation.NavType
+   import androidx.navigation.navArgument
+   ```
 
 12. Add a composable component right after `composable(route = EntitySetsDest.route) {}` block:
 
-    ```Kotlin
-    composable(
-        route = "error/{errorInfo}",
-        arguments = listOf(
-            navArgument("errorInfo") { type = NavType.StringType }
-        )
-    ) { backStackEntry ->
-        val errorInfo = backStackEntry.arguments?.getString("errorInfo")
-        ErrorScreen(navController::navigateUp, errorInfo)
-    }
-    ```
+   ```Kotlin
+   composable(
+       route = "error/{errorInfo}",
+       arguments = listOf(
+           navArgument("errorInfo") { type = NavType.StringType }
+       )
+   ) { backStackEntry ->
+       val errorInfo = backStackEntry.arguments?.getString("errorInfo")
+       ErrorScreen(navController::navigateUp, errorInfo)
+   }
+   ```
 
 13. Replace the `composable(route = EntitySetsDest.route) {}` block with the following:
 
-    ```Kotlin
-    composable(route = EntitySetsDest.route) {
-        EntitySetScreen(
-            getEntitySetScreenInfoList(),
-            navController::navigateToEntityList,
-            navigateToSettings = { navController.navigate(SETTINGS_SCREEN_ROUTE) },
-            navigateToErrorScreen = { errorInfo ->
-                navController.navigate("error/${errorInfo}")
-            }
-        )
-    }
-    ```
+   ```Kotlin
+   composable(route = EntitySetsDest.route) {
+       EntitySetScreen(
+           getEntitySetScreenInfoList(),
+           navController::navigateToEntityList,
+           navigateToSettings = { navController.navigate(SETTINGS_SCREEN_ROUTE) },
+           navigateToErrorScreen = { errorInfo ->
+               navController.navigate("error/${errorInfo}")
+           }
+       )
+   }
+   ```
 
 14. Run the app again, and re-attempt the sync. When the sync fails, you should see the following error screen.
 
@@ -714,14 +714,14 @@ In this section we will create an **Error Information** screen that displays the
 
 2.  Add the following values.
 
-    ```XML
-    <string name="error_header">Error Information</string>
-    <string name="request_method">Request Method</string>
-    <string name="request_status">Request Status</string>
-    <string name="request_message">Request Message</string>
-    <string name="request_body">Request Body</string>
-    <string name="request_url">Request URL</string>
-    ```
+   ```XML
+   <string name="error_header">Error Information</string>
+   <string name="request_method">Request Method</string>
+   <string name="request_status">Request Status</string>
+   <string name="request_message">Request Message</string>
+   <string name="request_body">Request Body</string>
+   <string name="request_url">Request URL</string>
+   ```
 
 3.  Create a new activity in the `app/kotlin+java/com.sap.wizapp/mdui` folder by right-clicking, then selecting **New** > **Activity** > **Empty Views Activity**. Name the new activity **`ErrorActivity`**.
 
@@ -729,328 +729,328 @@ In this section we will create an **Error Information** screen that displays the
 
 5.  Replace its contents with the following XML.
 
-    ```XML
-    <?xml version="1.0" encoding="utf-8"?>
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fitsSystemWindows="true"
-        tools:context=".mdui.ErrorActivity"
-        android:orientation="vertical">
+   ```XML
+   <?xml version="1.0" encoding="utf-8"?>
+   <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:app="http://schemas.android.com/apk/res-auto"
+       xmlns:tools="http://schemas.android.com/tools"
+       android:layout_width="match_parent"
+       android:layout_height="match_parent"
+       android:fitsSystemWindows="true"
+       tools:context=".mdui.ErrorActivity"
+       android:orientation="vertical">
 
-        <com.google.android.material.appbar.AppBarLayout
-            android:id="@+id/app_bar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+       <com.google.android.material.appbar.AppBarLayout
+           android:id="@+id/app_bar"
+           android:layout_width="match_parent"
+           android:layout_height="wrap_content">
 
-            <androidx.appcompat.widget.Toolbar
-                android:id="@+id/toolbar"
-                android:layout_width="match_parent"
-                android:layout_height="?attr/actionBarSize"
-                app:popupTheme="@style/AppTheme.PopupOverlay"
-                app:titleTextColor="@color/colorBlack" />
+           <androidx.appcompat.widget.Toolbar
+               android:id="@+id/toolbar"
+               android:layout_width="match_parent"
+               android:layout_height="?attr/actionBarSize"
+               app:popupTheme="@style/AppTheme.PopupOverlay"
+               app:titleTextColor="@color/colorBlack" />
 
-        </com.google.android.material.appbar.AppBarLayout>
+       </com.google.android.material.appbar.AppBarLayout>
 
-        <ScrollView
-            android:layout_height="wrap_content"
-            android:layout_width="match_parent">
+       <ScrollView
+           android:layout_height="wrap_content"
+           android:layout_width="match_parent">
 
-            <LinearLayout
-                android:layout_height="wrap_content"
-                android:layout_width="match_parent"
-                android:orientation="vertical">
+           <LinearLayout
+               android:layout_height="wrap_content"
+               android:layout_width="match_parent"
+               android:orientation="vertical">
 
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:padding="@dimen/key_line_16dp"
-                    style="@style/Test.ObjectCell.Headline"
-                    android:text="@string/error_header"/>
+               <TextView
+                   android:layout_width="match_parent"
+                   android:layout_height="wrap_content"
+                   android:padding="@dimen/key_line_16dp"
+                   style="@style/Test.ObjectCell.Headline"
+                   android:text="@string/error_header"/>
 
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_marginTop="@dimen/key_line_16dp"
-                    android:layout_height="1dp"
-                    android:background="?android:attr/listDivider" />
+               <View
+                   android:layout_width="match_parent"
+                   android:layout_marginTop="@dimen/key_line_16dp"
+                   android:layout_height="1dp"
+                   android:background="?android:attr/listDivider" />
 
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:padding="@dimen/key_line_16dp"
-                    style="@style/FioriTextStyle.OVERLINE"
-                    android:text="@string/request_message"/>
+               <TextView
+                   android:layout_width="match_parent"
+                   android:layout_height="wrap_content"
+                   android:padding="@dimen/key_line_16dp"
+                   style="@style/FioriTextStyle.OVERLINE"
+                   android:text="@string/request_message"/>
 
-                <TextView
-                    android:id="@+id/requestMessageTextView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:paddingLeft="@dimen/key_line_16dp"
-                    android:paddingRight="@dimen/key_line_16dp"
-                    style="@style/TextAppearance.Fiori.Subtitle1"
-                    android:singleLine="false"
-                    android:text="@string/request_message"/>
+               <TextView
+                   android:id="@+id/requestMessageTextView"
+                   android:layout_width="match_parent"
+                   android:layout_height="wrap_content"
+                   android:paddingLeft="@dimen/key_line_16dp"
+                   android:paddingRight="@dimen/key_line_16dp"
+                   style="@style/TextAppearance.Fiori.Subtitle1"
+                   android:singleLine="false"
+                   android:text="@string/request_message"/>
 
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_marginTop="@dimen/key_line_16dp"
-                    android:layout_height="1dp"
-                    android:background="?android:attr/listDivider" />
+               <View
+                   android:layout_width="match_parent"
+                   android:layout_marginTop="@dimen/key_line_16dp"
+                   android:layout_height="1dp"
+                   android:background="?android:attr/listDivider" />
 
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:padding="@dimen/key_line_16dp"
-                    style="@style/FioriTextStyle.OVERLINE"
-                    android:text="@string/request_body"/>
+               <TextView
+                   android:layout_width="match_parent"
+                   android:layout_height="wrap_content"
+                   android:padding="@dimen/key_line_16dp"
+                   style="@style/FioriTextStyle.OVERLINE"
+                   android:text="@string/request_body"/>
 
-                <TextView
-                    android:id="@+id/requestBodyTextView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:paddingLeft="@dimen/key_line_16dp"
-                    android:paddingRight="@dimen/key_line_16dp"
-                    style="@style/TextAppearance.Fiori.Subtitle1"
-                    android:singleLine="false"
-                    android:text="@string/request_body"/>
+               <TextView
+                   android:id="@+id/requestBodyTextView"
+                   android:layout_width="match_parent"
+                   android:layout_height="wrap_content"
+                   android:paddingLeft="@dimen/key_line_16dp"
+                   android:paddingRight="@dimen/key_line_16dp"
+                   style="@style/TextAppearance.Fiori.Subtitle1"
+                   android:singleLine="false"
+                   android:text="@string/request_body"/>
 
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_marginTop="@dimen/key_line_16dp"
-                    android:layout_height="1dp"
-                    android:background="?android:attr/listDivider" />
+               <View
+                   android:layout_width="match_parent"
+                   android:layout_marginTop="@dimen/key_line_16dp"
+                   android:layout_height="1dp"
+                   android:background="?android:attr/listDivider" />
 
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:padding="@dimen/key_line_16dp"
-                    style="@style/FioriTextStyle.OVERLINE"
-                    android:text="@string/request_url"/>
+               <TextView
+                   android:layout_width="match_parent"
+                   android:layout_height="wrap_content"
+                   android:padding="@dimen/key_line_16dp"
+                   style="@style/FioriTextStyle.OVERLINE"
+                   android:text="@string/request_url"/>
 
-                <TextView
-                    android:id="@+id/requestURLTextView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:paddingLeft="@dimen/key_line_16dp"
-                    android:paddingRight="@dimen/key_line_16dp"
-                    style="@style/TextAppearance.Fiori.Subtitle1"
-                    android:singleLine="false"
-                    android:text="@string/request_url"/>
+               <TextView
+                   android:id="@+id/requestURLTextView"
+                   android:layout_width="match_parent"
+                   android:layout_height="wrap_content"
+                   android:paddingLeft="@dimen/key_line_16dp"
+                   android:paddingRight="@dimen/key_line_16dp"
+                   style="@style/TextAppearance.Fiori.Subtitle1"
+                   android:singleLine="false"
+                   android:text="@string/request_url"/>
 
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_marginTop="@dimen/key_line_16dp"
-                    android:layout_height="1dp"
-                    android:background="?android:attr/listDivider" />
+               <View
+                   android:layout_width="match_parent"
+                   android:layout_marginTop="@dimen/key_line_16dp"
+                   android:layout_height="1dp"
+                   android:background="?android:attr/listDivider" />
 
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:padding="@dimen/key_line_16dp"
-                    style="@style/FioriTextStyle.OVERLINE"
-                    android:text="@string/request_status"/>
+               <TextView
+                   android:layout_width="match_parent"
+                   android:layout_height="wrap_content"
+                   android:padding="@dimen/key_line_16dp"
+                   style="@style/FioriTextStyle.OVERLINE"
+                   android:text="@string/request_status"/>
 
-                <TextView
-                    android:id="@+id/requestStatusTextView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:paddingLeft="@dimen/key_line_16dp"
-                    style="@style/TextAppearance.Fiori.Subtitle1"
-                    android:text="@string/request_status"/>
+               <TextView
+                   android:id="@+id/requestStatusTextView"
+                   android:layout_width="match_parent"
+                   android:layout_height="wrap_content"
+                   android:paddingLeft="@dimen/key_line_16dp"
+                   style="@style/TextAppearance.Fiori.Subtitle1"
+                   android:text="@string/request_status"/>
 
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_marginTop="@dimen/key_line_16dp"
-                    android:layout_height="1dp"
-                    android:background="?android:attr/listDivider" />
+               <View
+                   android:layout_width="match_parent"
+                   android:layout_marginTop="@dimen/key_line_16dp"
+                   android:layout_height="1dp"
+                   android:background="?android:attr/listDivider" />
 
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:padding="@dimen/key_line_16dp"
-                    style="@style/FioriTextStyle.OVERLINE"
-                    android:text="@string/request_method"/>
+               <TextView
+                   android:layout_width="match_parent"
+                   android:layout_height="wrap_content"
+                   android:padding="@dimen/key_line_16dp"
+                   style="@style/FioriTextStyle.OVERLINE"
+                   android:text="@string/request_method"/>
 
-                <TextView
-                    android:id="@+id/requestMethodTextView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:paddingLeft="@dimen/key_line_16dp"
-                    style="@style/TextAppearance.Fiori.Subtitle1"
-                    android:text="@string/request_method"/>
+               <TextView
+                   android:id="@+id/requestMethodTextView"
+                   android:layout_width="match_parent"
+                   android:layout_height="wrap_content"
+                   android:paddingLeft="@dimen/key_line_16dp"
+                   style="@style/TextAppearance.Fiori.Subtitle1"
+                   android:text="@string/request_method"/>
 
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_marginTop="@dimen/key_line_16dp"
-                    android:layout_height="1dp"
-                    android:background="?android:attr/listDivider" />
-            </LinearLayout>
-        </ScrollView>
-    </LinearLayout>
-    ```
+               <View
+                   android:layout_width="match_parent"
+                   android:layout_marginTop="@dimen/key_line_16dp"
+                   android:layout_height="1dp"
+                   android:background="?android:attr/listDivider" />
+           </LinearLayout>
+       </ScrollView>
+   </LinearLayout>
+   ```
 
 6.  Replace the `ErrorActivity.kt` generated activity code with the following code.
 
     In the package statement and the import, if needed, replace `com.sap.wizapp` with the package name of your project.
 
-    ```Kotlin
-    package com.sap.wizapp.mdui
+   ```Kotlin
+   package com.sap.wizapp.mdui
 
-    import androidx.appcompat.app.AppCompatActivity
-    import android.os.Bundle
-    import android.view.MenuItem
-    import android.view.View
-    import android.widget.TextView
+   import androidx.appcompat.app.AppCompatActivity
+   import android.os.Bundle
+   import android.view.MenuItem
+   import android.view.View
+   import android.widget.TextView
 
-    import com.sap.wizapp.R
+   import com.sap.wizapp.R
 
-    class ErrorActivity : AppCompatActivity() {
+   class ErrorActivity : AppCompatActivity() {
 
-        override fun onCreate(savedInstanceState: Bundle?) {
-            super.onCreate(savedInstanceState)
-            setContentView(R.layout.activity_error)
-            setSupportActionBar(findViewById(R.id.toolbar))
-            supportActionBar!!.setDisplayHomeAsUpEnabled(true)
-            val errorCode = intent.getIntExtra("ERROR_CODE", 0)
-            val errorMethod = intent.getStringExtra("ERROR_METHOD")
-            val requestURL = intent.getStringExtra("ERROR_URL")
-            val errorMessage = intent.getStringExtra("ERROR_MESSAGE")
-            val body = intent.getStringExtra("ERROR_BODY")
-            (findViewById<View>(R.id.requestStatusTextView) as TextView).text = "".plus(errorCode)
+       override fun onCreate(savedInstanceState: Bundle?) {
+           super.onCreate(savedInstanceState)
+           setContentView(R.layout.activity_error)
+           setSupportActionBar(findViewById(R.id.toolbar))
+           supportActionBar!!.setDisplayHomeAsUpEnabled(true)
+           val errorCode = intent.getIntExtra("ERROR_CODE", 0)
+           val errorMethod = intent.getStringExtra("ERROR_METHOD")
+           val requestURL = intent.getStringExtra("ERROR_URL")
+           val errorMessage = intent.getStringExtra("ERROR_MESSAGE")
+           val body = intent.getStringExtra("ERROR_BODY")
+           (findViewById<View>(R.id.requestStatusTextView) as TextView).text = "".plus(errorCode)
 
-            errorMethod?.let {
-                (findViewById<View>(R.id.requestMethodTextView) as TextView).text = it
-            }
-            requestURL?.let {
-                (findViewById<View>(R.id.requestURLTextView) as TextView).text = it
-            }
-            errorMessage?.let {
-                (findViewById<View>(R.id.requestMessageTextView) as TextView).text = it
-            }
-            body?.let {
-                (findViewById<View>(R.id.requestBodyTextView) as TextView).text = it
-            }
-        }
+           errorMethod?.let {
+               (findViewById<View>(R.id.requestMethodTextView) as TextView).text = it
+           }
+           requestURL?.let {
+               (findViewById<View>(R.id.requestURLTextView) as TextView).text = it
+           }
+           errorMessage?.let {
+               (findViewById<View>(R.id.requestMessageTextView) as TextView).text = it
+           }
+           body?.let {
+               (findViewById<View>(R.id.requestBodyTextView) as TextView).text = it
+           }
+       }
 
-        override fun onOptionsItemSelected(item: MenuItem): Boolean {
-            finish()
-            return super.onOptionsItemSelected(item)
-        }
-    }
-    ```
+       override fun onOptionsItemSelected(item: MenuItem): Boolean {
+           finish()
+           return super.onOptionsItemSelected(item)
+       }
+   }
+   ```
 
 7.  On Windows, press **`Ctrl+N`**, or, on a Mac, press **`command+O`**, and type **`EntitySetListActivity`** to open `EntitySetListActivity.kt`.
 
 8.  In the `updateProgressForSync` method, in the `WorkInfo.State.SUCCEEDED` block, add the following code, which queries the error archive and displays information to the user about the first error encountered:
 
-    ```Kotlin
-    val provider = OfflineWorkerUtil.offlineODataProvider
+   ```Kotlin
+   val provider = OfflineWorkerUtil.offlineODataProvider
 
-    try {
-        val errorArchive = provider!!.errorArchive
+   try {
+       val errorArchive = provider!!.errorArchive
 
-        for (errorEntity in errorArchive) {
-            val requestURL = errorEntity.requestURL
-            val method = errorEntity.requestMethod
-            val message = errorEntity.message
-            val statusCode = errorEntity.httpStatusCode ?: 0
-            val body = errorEntity.requestBody
+       for (errorEntity in errorArchive) {
+           val requestURL = errorEntity.requestURL
+           val method = errorEntity.requestMethod
+           val message = errorEntity.message
+           val statusCode = errorEntity.httpStatusCode ?: 0
+           val body = errorEntity.requestBody
 
-            LOGGER.error("RequestURL: $requestURL")
-            LOGGER.error("HTTP Status Code: $statusCode")
-            LOGGER.error("Method: $method")
-            LOGGER.error("Message: $message")
-            LOGGER.error("Body: $body")
+           LOGGER.error("RequestURL: $requestURL")
+           LOGGER.error("HTTP Status Code: $statusCode")
+           LOGGER.error("Method: $method")
+           LOGGER.error("Message: $message")
+           LOGGER.error("Body: $body")
 
-            val errorIntent = Intent(this@EntitySetListActivity, ErrorActivity::class.java)
+           val errorIntent = Intent(this@EntitySetListActivity, ErrorActivity::class.java)
 
-            errorIntent.putExtra("ERROR_URL", requestURL)
-            errorIntent.putExtra("ERROR_CODE", statusCode)
-            errorIntent.putExtra("ERROR_METHOD", method)
-            errorIntent.putExtra("ERROR_BODY", body)
+           errorIntent.putExtra("ERROR_URL", requestURL)
+           errorIntent.putExtra("ERROR_CODE", statusCode)
+           errorIntent.putExtra("ERROR_METHOD", method)
+           errorIntent.putExtra("ERROR_BODY", body)
 
-            try {
-                val jsonObj = message?.let { JSONObject(it) }
-                jsonObj?.let {
-                    errorIntent.putExtra(
-                        "ERROR_MESSAGE",
-                        jsonObj.getJSONObject("error").getString("message")
-                    )
-                }
-            } catch (e: JSONException) {
-                e.printStackTrace()
-            }
+           try {
+               val jsonObj = message?.let { JSONObject(it) }
+               jsonObj?.let {
+                   errorIntent.putExtra(
+                       "ERROR_MESSAGE",
+                       jsonObj.getJSONObject("error").getString("message")
+                   )
+               }
+           } catch (e: JSONException) {
+               e.printStackTrace()
+           }
 
-            // Reverts all failing entities to the previous state or set
-            // offlineODataParameters.setEnableIndividualErrorArchiveDeletion(true);
-            // to cause the deleteEntity call to only revert the specified entity
-            // https://help.sap.com/doc/f53c64b93e5140918d676b927a3cd65b/Cloud/en-US/docs-en/guides/features/offline/common/handling-failed-requests/reverting-error-state.html
-            // provider.deleteEntity(errorEntity, null, null);
-            startActivity(errorIntent)
-            break //For simplicity, only show the first error encountered
-        }
-    } catch (e: OfflineODataException) {
-        e.printStackTrace()
-    }
-    ```
+           // Reverts all failing entities to the previous state or set
+           // offlineODataParameters.setEnableIndividualErrorArchiveDeletion(true);
+           // to cause the deleteEntity call to only revert the specified entity
+           // https://help.sap.com/doc/f53c64b93e5140918d676b927a3cd65b/Cloud/en-US/docs-en/guides/features/offline/common/handling-failed-requests/reverting-error-state.html
+           // provider.deleteEntity(errorEntity, null, null);
+           startActivity(errorIntent)
+           break //For simplicity, only show the first error encountered
+       }
+   } catch (e: OfflineODataException) {
+       e.printStackTrace()
+   }
+   ```
 
-    After modification, the `WorkInfo.State.SUCCEEDED` block should look like this:
+   After modification, the `WorkInfo.State.SUCCEEDED` block should look like this:
 
-    ```Kotlin
-    WorkInfo.State.SUCCEEDED -> {
-        LOGGER.info("Offline sync done.")
-        val provider = OfflineWorkerUtil.offlineODataProvider
+   ```Kotlin
+   WorkInfo.State.SUCCEEDED -> {
+       LOGGER.info("Offline sync done.")
+       val provider = OfflineWorkerUtil.offlineODataProvider
 
-        try {
-            val errorArchive = provider!!.errorArchive
+       try {
+           val errorArchive = provider!!.errorArchive
 
-            for (errorEntity in errorArchive) {
-                val requestURL = errorEntity.requestURL
-                val method = errorEntity.requestMethod
-                val message = errorEntity.message
-                val statusCode = errorEntity.httpStatusCode ?: 0
-                val body = errorEntity.requestBody
+           for (errorEntity in errorArchive) {
+               val requestURL = errorEntity.requestURL
+               val method = errorEntity.requestMethod
+               val message = errorEntity.message
+               val statusCode = errorEntity.httpStatusCode ?: 0
+               val body = errorEntity.requestBody
 
-                LOGGER.error("RequestURL: $requestURL")
-                LOGGER.error("HTTP Status Code: $statusCode")
-                LOGGER.error("Method: $method")
-                LOGGER.error("Message: $message")
-                LOGGER.error("Body: $body")
+               LOGGER.error("RequestURL: $requestURL")
+               LOGGER.error("HTTP Status Code: $statusCode")
+               LOGGER.error("Method: $method")
+               LOGGER.error("Message: $message")
+               LOGGER.error("Body: $body")
 
-                val errorIntent = Intent(this@EntitySetListActivity, ErrorActivity::class.java)
+               val errorIntent = Intent(this@EntitySetListActivity, ErrorActivity::class.java)
 
-                errorIntent.putExtra("ERROR_URL", requestURL)
-                errorIntent.putExtra("ERROR_CODE", statusCode)
-                errorIntent.putExtra("ERROR_METHOD", method)
-                errorIntent.putExtra("ERROR_BODY", body)
+               errorIntent.putExtra("ERROR_URL", requestURL)
+               errorIntent.putExtra("ERROR_CODE", statusCode)
+               errorIntent.putExtra("ERROR_METHOD", method)
+               errorIntent.putExtra("ERROR_BODY", body)
 
-                try {
-                    val jsonObj = message?.let { JSONObject(it) }
-                    jsonObj?.let {
-                        errorIntent.putExtra(
-                            "ERROR_MESSAGE",
-                            jsonObj.getJSONObject("error").getString("message")
-                        )
-                    }
-                } catch (e: JSONException) {
-                    e.printStackTrace()
-                }
+               try {
+                   val jsonObj = message?.let { JSONObject(it) }
+                   jsonObj?.let {
+                       errorIntent.putExtra(
+                           "ERROR_MESSAGE",
+                           jsonObj.getJSONObject("error").getString("message")
+                       )
+                   }
+               } catch (e: JSONException) {
+                   e.printStackTrace()
+               }
 
-                // Reverts all failing entities to the previous state or set
-                // offlineODataParameters.setEnableIndividualErrorArchiveDeletion(true);
-                // to cause the deleteEntity call to only revert the specified entity
-                // https://help.sap.com/doc/f53c64b93e5140918d676b927a3cd65b/Cloud/en-US/docs-en/guides/features/offline/common/handling-failed-requests/reverting-error-state.html
-                // provider.deleteEntity(errorEntity, null, null);
-                startActivity(errorIntent)
-                break //For simplicity, only show the first error encountered
-            }
-        } catch (e: OfflineODataException) {
-            e.printStackTrace()
-        }
-    }
-    ```
+               // Reverts all failing entities to the previous state or set
+               // offlineODataParameters.setEnableIndividualErrorArchiveDeletion(true);
+               // to cause the deleteEntity call to only revert the specified entity
+               // https://help.sap.com/doc/f53c64b93e5140918d676b927a3cd65b/Cloud/en-US/docs-en/guides/features/offline/common/handling-failed-requests/reverting-error-state.html
+               // provider.deleteEntity(errorEntity, null, null);
+               startActivity(errorIntent)
+               break //For simplicity, only show the first error encountered
+           }
+       } catch (e: OfflineODataException) {
+           e.printStackTrace()
+       }
+   }
+   ```
 
 
 9.  Run the app again, and re-attempt the sync. When the sync fails, you should see the following error screen.

--- a/tutorials/sdk-android-wizard-app-usage/sdk-android-wizard-app-usage.md
+++ b/tutorials/sdk-android-wizard-app-usage/sdk-android-wizard-app-usage.md
@@ -217,17 +217,17 @@ The following steps record how often users start adding or updating products but
 
 3. Add the following code segment to the very beginning of the method:
 
-    ```Kotlin
-    SDKInitializer.getService(UsageService::class)?.eventBehaviorUserInteraction(ODataViewModel::class.java.simpleName, "elementId", "edit${(this as EntityViewModel).entityType.localName}Clicked", "Begin Edit ${entityType.localName}")
-    ```
+   ```Kotlin
+   SDKInitializer.getService(UsageService::class)?.eventBehaviorUserInteraction(ODataViewModel::class.java.simpleName, "elementId", "edit${(this as EntityViewModel).entityType.localName}Clicked", "Begin Edit ${entityType.localName}")
+   ```
 
     This generates a usage event record for when a user taps the **Edit** icon within any entity screen.
 
 4. On Windows, press **`Ctrl+F12`**, or on a Mac, press **`command+F12`** and type **`onCreate`**, to navigate to the `onCreate` method. Add the following code segment to the very beginning of the method:
 
-    ```Kotlin
-    SDKInitializer.getService(UsageService::class)?.eventBehaviorUserInteraction(ODataViewModel::class.java.simpleName, "elementId", "create${(this as EntityViewModel).entityType.localName}Clicked", "Begin Create ${entityType.localName}")
-    ```
+   ```Kotlin
+   SDKInitializer.getService(UsageService::class)?.eventBehaviorUserInteraction(ODataViewModel::class.java.simpleName, "elementId", "create${(this as EntityViewModel).entityType.localName}Clicked", "Begin Create ${entityType.localName}")
+   ```
 
     This generates a usage event record for when a user taps the **Add** icon within any entity screen.
 
@@ -235,18 +235,18 @@ The following steps record how often users start adding or updating products but
 
 6. On Windows, press **`Ctrl+F12`**, or on a Mac, press **`command+F12`** and type **`exitCreation`**, to navigate to the `exitCreation` method. Add the following code segment to the very beginning of the method:
 
-    ```Kotlin
-    SDKInitializer.getService(UsageService::class)?.eventBehaviorUserInteraction(EntityViewModel::class.java.simpleName, "elementId", "onBackPressed", "Create ${entityType.localName} Cancelled")
-    ```
+   ```Kotlin
+   SDKInitializer.getService(UsageService::class)?.eventBehaviorUserInteraction(EntityViewModel::class.java.simpleName, "elementId", "onBackPressed", "Create ${entityType.localName} Cancelled")
+   ```
 
     This generates the usage event record whenever the user navigates away from a creating screen without saving.
 
 7. Add the following imports if they are not auto-added:
 
-    ```Kotlin
-    import com.sap.cloud.mobile.foundation.mobileservices.SDKInitializer
-    import com.sap.cloud.mobile.foundation.usage.UsageService
-    ```
+   ```Kotlin
+   import com.sap.cloud.mobile.foundation.mobileservices.SDKInitializer
+   import com.sap.cloud.mobile.foundation.usage.UsageService
+   ```
 
 8. Build and run the app.
 
@@ -282,19 +282,19 @@ The following steps record how often users start adding or updating products but
 
 18. In the four empty cells on the Excel spreadsheet, label two of them with **`Product Create or Edit Clicked`** and **`Cancelled Product Create`** respectively. Next to `Product Create or Edit Clicked`, use the following formula to find the number of times the user intended to add/update a product:
 
-    ```Excel
-    =COUNTIF(R:R, "*createProductClicked*")+COUNTIF(R:R, "*editProductClicked*")
-    ```
+   ```Excel
+   =COUNTIF(R:R, "*createProductClicked*")+COUNTIF(R:R, "*editProductClicked*")
+   ```
 
 19. Next to `Cancelled Product Create`, use the following formula to find the number of times the user cancelled an add product action:
 
-    ```Excel
-    =COUNTIF(R:R, "*onBackPressed*")
-    ```
+   ```Excel
+   =COUNTIF(R:R, "*onBackPressed*")
+   ```
 
-    In the example, the user tried to create a product three times but cancelled three times, and edited it once.
+   In the example, the user tried to create a product three times but cancelled three times, and edited it once.
 
-    ![Counting Product Creation and Cancellations with Excel Formulas](excel_formulas_jc.png)
+   ![Counting Product Creation and Cancellations with Excel Formulas](excel_formulas_jc.png)
 
 [OPTION END]
 
@@ -306,26 +306,26 @@ The following steps record how often users start adding or updating products but
 
 3. Find the following line:
 
-    ```Kotlin
-    super.onCreate(savedInstanceState)
-    ```
+   ```Kotlin
+   super.onCreate(savedInstanceState)
+   ```
 
 4. Add the following code segment immediately after:
 
-    ```Kotlin
-    SDKInitializer.getService(UsageService::class)?.eventBehaviorUserInteraction(ProductsCreateFragment::class.java.simpleName, "elementId", "createOrEditProductClicked", "Begin Create or Edit Product")
-    ```
+   ```Kotlin
+   SDKInitializer.getService(UsageService::class)?.eventBehaviorUserInteraction(ProductsCreateFragment::class.java.simpleName, "elementId", "createOrEditProductClicked", "Begin Create or Edit Product")
+   ```
 
     This generates a usage event record for when a user taps the **Add** or **Edit** icon within **Products**.
 
 5. On Windows, press **`Ctrl+F12`**, or on a Mac, press **`command+F12`** and type **`onMenuItemSelected`**, to navigate to the `onMenuItemSelected` method. Add the following code segment before the `else` case in the same file:
 
-    ```Kotlin
-    android.R.id.home -> {
-        SDKInitializer.getService(UsageService::class)?.eventBehaviorUserInteraction(ProductsCreateFragment::class.java.simpleName, "elementId", "onBackPressed", "Create or Edit Product Cancelled")
-        super.onMenuItemSelected(menuItem)
-    }
-    ```
+   ```Kotlin
+   android.R.id.home -> {
+       SDKInitializer.getService(UsageService::class)?.eventBehaviorUserInteraction(ProductsCreateFragment::class.java.simpleName, "elementId", "onBackPressed", "Create or Edit Product Cancelled")
+       super.onMenuItemSelected(menuItem)
+   }
+   ```
 
     This generates the usage event record whenever the user navigates away from an editing screen without saving.
 
@@ -363,19 +363,19 @@ The following steps record how often users start adding or updating products but
 
 16. In the four empty cells that are not in the `R` ( `I_ACTION` ) column on the Excel spreadsheet, label two of them with **`Product Create or Edit Clicked`** and **`Cancelled Product Create or Edit`** respectively. Next to `Product Create or Edit Clicked`, use the following formula to find the number of times the user intended to add/update a product:
 
-    ```Excel
-    =COUNTIF(R:R, "*createOrEditProductClicked*")
-    ```
+   ```Excel
+   =COUNTIF(R:R, "*createOrEditProductClicked*")
+   ```
 
 17. Next to `Cancelled Product Create or Edit`, use the following formula to find the number of times the user cancelled an add/update product action:
 
-    ```Excel
-    =COUNTIF(R:R, "*onBackPressed*")
-    ```
+   ```Excel
+   =COUNTIF(R:R, "*onBackPressed*")
+   ```
 
-    In the example, the user tried to create a product three times but cancelled three times, and edit it once.
+   In the example, the user tried to create a product three times but cancelled three times, and edit it once.
 
-    ![Counting Product Creation and Cancellations with Excel Formulas](excel_formulas.png)
+   ![Counting Product Creation and Cancellations with Excel Formulas](excel_formulas.png)
 
 [OPTION END]
 
@@ -393,74 +393,74 @@ Mobile Services provides a **Client Usage Configuration** under **Mobile Client 
 
 3.  Near the end of the class, add the following companion objects:
 
-    ```Kotlin
-    private var isUsageEnabled: Boolean = false
-    private var uploadInterval: Int = 0
-    ```
+   ```Kotlin
+   private var isUsageEnabled: Boolean = false
+   private var uploadInterval: Int = 0
+   ```
 
 4.  On Windows, press **`Ctrl+F12`**, or on a Mac, press **`command+F12`**, and type **`onClientPolicyRetrieved`** to navigate to the `onClientPolicyRetrieved` method.
 
 5.  At the end of the method, add the following code:
 
-    ```Kotlin
-    policies.usagePolicy?.also {
-        isUsageEnabled = it.dataCollectionEnabled
-        uploadInterval = it.uploadDataAfterDays
-        if (isUsageEnabled) {
-            UsageBroker.setDataCollectionEnabled(isUsageEnabled)
-            uploadUsage()
-        }
-    }
-    ```
+   ```Kotlin
+   policies.usagePolicy?.also {
+       isUsageEnabled = it.dataCollectionEnabled
+       uploadInterval = it.uploadDataAfterDays
+       if (isUsageEnabled) {
+           UsageBroker.setDataCollectionEnabled(isUsageEnabled)
+           uploadUsage()
+       }
+   }
+   ```
 
-    This code gets the usage policy information from the server client policy and stores it inside global variables.
+   This code gets the usage policy information from the server client policy and stores it inside global variables.
 
 6.  Add the following method in the class:
 
-    ```Kotlin
-    private fun uploadUsage() {
-        UsageBroker.setDaysToWaitBetweenUpload(uploadInterval)
+   ```Kotlin
+   private fun uploadUsage() {
+       UsageBroker.setDaysToWaitBetweenUpload(uploadInterval)
 
-        //if uploadInterval is greater than 0 then auto-upload is considered to be enabled on Mobile Services
-        if (uploadInterval > 0) {
-            // The upload will only occur if the last upload was more than newDays ago
-            AppUsageUploader.addUploadListener(object: AppUsageUploader.UploadListener {
-                override fun onSuccess() {
-                    Toast.makeText(application, application.getString(R.string.usage_upload_ok), Toast.LENGTH_LONG).show()
-                }
+       //if uploadInterval is greater than 0 then auto-upload is considered to be enabled on Mobile Services
+       if (uploadInterval > 0) {
+           // The upload will only occur if the last upload was more than newDays ago
+           AppUsageUploader.addUploadListener(object: AppUsageUploader.UploadListener {
+               override fun onSuccess() {
+                   Toast.makeText(application, application.getString(R.string.usage_upload_ok), Toast.LENGTH_LONG).show()
+               }
 
-                override fun onError(error: Throwable) {
-                    // make sure to import com.sap.cloud.mobile.foundation.networking.HttpException;
-                    if (error is HttpException) {
-                        logger.debug("Usage Upload server error: {}, code = {}", error.message(), error.code())
-                    } else {
-                        logger.debug("Usage Upload error: {}", error.message)
-                    }
+               override fun onError(error: Throwable) {
+                   // make sure to import com.sap.cloud.mobile.foundation.networking.HttpException;
+                   if (error is HttpException) {
+                       logger.debug("Usage Upload server error: {}, code = {}", error.message(), error.code())
+                   } else {
+                       logger.debug("Usage Upload error: {}", error.message)
+                   }
 
-                    val errorMessage = application.getString(R.string.usage_upload_failed)
-                    logger.error(errorMessage, error)
-                }
+                   val errorMessage = application.getString(R.string.usage_upload_failed)
+                   logger.error(errorMessage, error)
+               }
 
-                override fun onProgress(i: Int) {
-                    logger.debug("Usage upload progress: $i")
-                }
-            })
-            UsageBroker.upload(application, false)
-        }
-    }
-    ```
+               override fun onProgress(i: Int) {
+                   logger.debug("Usage upload progress: $i")
+               }
+           })
+           UsageBroker.upload(application, false)
+       }
+   }
+   ```
 
-    This code sets the upload interval for the application's `UsageBroker` object and then requests an upload of usage. If the amount of days between uploading is sufficient, it will upload the data and, if not, it will delay the upload. If the **Upload Report After** interval is 0 it will not upload any usage.
+   This code sets the upload interval for the application's `UsageBroker` object and then requests an upload of usage. If the amount of days between uploading is sufficient, it will upload the data and, if not, it will delay the upload. If the **Upload Report After** interval is 0 it will not upload any usage.
 
-    >There may be an error on `HttpException`. Select it and press **`Alt+Enter`** on Windows, or, press **`option+Enter`** on Macs, to import the related class from `com.sap.cloud.mobile.foundation.networking`.
+   >There may be an error on `HttpException`. Select it and press **`Alt+Enter`** on Windows, or, press **`option+Enter`** on Macs, to import the related class from `com.sap.cloud.mobile.foundation.networking`.
 
 7.  In Android Studio, on Windows, press **`Ctrl+N`**, or on a Mac, press **`command+O`**, and type **`SettingsViewModel`** to open `SettingsViewModel.kt`.
 
 8.  On Windows, press **`Ctrl+F`**, or on a Mac, press **`command+F`**, to find:
 
-    ```Kotlin
-    usageService.uploadUsageData(forceUpload = true, owner = lifecycleOwner,
-    ```
+   ```Kotlin
+   usageService.uploadUsageData(forceUpload = true, owner = lifecycleOwner,
+   ```
 
 9.  When `forceUpload` is set to `true`, the user can upload the usage report through the app's settings screen, regardless of the number of days specified in the policy.
 


### PR DESCRIPTION
Automated conservative, idempotent fixes for malformed-markdown patterns that the
tutorials-ims render pipeline currently patches in flight (sap-tutorials/tutorials-ims#1963).


Classes fixed: list-continuation-fence, list-continuation-prose

Tutorials (17):
- `tutorials/sdk-android-app-link/sdk-android-app-link.md`
- `tutorials/sdk-android-flowjc-custom/sdk-android-flowjc-custom.md`
- `tutorials/sdk-android-flows-custom/sdk-android-flows-custom.md`
- `tutorials/sdk-android-flows-onboarding/sdk-android-flows-onboarding.md`
- `tutorials/sdk-android-flows-passcode/sdk-android-flows-passcode.md`
- `tutorials/sdk-android-flows-restore/sdk-android-flows-restore.md`
- `tutorials/sdk-android-flows-theme/sdk-android-flows-theme.md`
- `tutorials/sdk-android-flowsjc-onboarding/sdk-android-flowsjc-onboarding.md`
- `tutorials/sdk-android-flowsjc-passcode/sdk-android-flowsjc-passcode.md`
- `tutorials/sdk-android-flowsjc-restore/sdk-android-flowsjc-restore.md`
- `tutorials/sdk-android-flowsjc-wizard/sdk-android-flowsjc-wizard.md`
- `tutorials/sdk-android-wizard-app-customize/sdk-android-wizard-app-customize.md`
- `tutorials/sdk-android-wizard-app-logging/sdk-android-wizard-app-logging.md`
- `tutorials/sdk-android-wizard-app-map/sdk-android-wizard-app-map.md`
- `tutorials/sdk-android-wizard-app-multiuser/sdk-android-wizard-app-multiuser.md`
- `tutorials/sdk-android-wizard-app-offline/sdk-android-wizard-app-offline.md`
- `tutorials/sdk-android-wizard-app-usage/sdk-android-wizard-app-usage.md`

Each change is idempotent and verified by a golden-render gate: composing the original
vs. fixed source through the pipeline yields byte-identical steps/body/intro.

🤖 Generated with Claude Code